### PR TITLE
Increase scenario impactor size for Chihuahua strike

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,13 @@ function App() {
   const [orbitalData, setOrbitalData] = useState<OrbitalData | null>(null)
   const [selectedNEO, setSelectedNEO] = useState<NEO | null>(null)
   const [impactParams, setImpactParams] = useState<ImpactParams>({
-    diameter: 120,
+    diameter: 2000,
     velocity: 17,
     density: 3000,
     target: 'continental'
   })
   const [impactResults, setImpactResults] = useState<ImpactResults | null>(null)
-  const [impactLocation, setImpactLocation] = useState<[number, number]>([29.07, -105.56])
+  const [impactLocation, setImpactLocation] = useState<[number, number]>([28.632995, -106.0691])
 
   const handleNEOSelect = (neo: NEO, orbital: OrbitalData) => {
     setSelectedNEO(neo)

--- a/src/data/scenarioNeos.ts
+++ b/src/data/scenarioNeos.ts
@@ -6,8 +6,8 @@ export const IMPACTOR_2025: NEO = {
   is_potentially_hazardous_asteroid: true,
   estimated_diameter: {
     meters: {
-      estimated_diameter_min: 330,
-      estimated_diameter_max: 350,
+      estimated_diameter_min: 1900,
+      estimated_diameter_max: 2100,
     },
   },
   close_approach_data: [
@@ -31,11 +31,12 @@ export const IMPACTOR_2025: NEO = {
   impact_scenario: {
     probability: 1,
     impact_date: '2025-10-17T14:22:00Z',
-    location: [29.07, -105.56],
+    location: [28.632995, -106.0691],
     surface_type: 'continental',
     material_density: 3200,
     narrative:
       'Scenario exercise: modeled impact trajectory derived from NeoWs elements with forced Earth intercept on 17 Oct 2025. '
+      + 'This variant assumes a direct strike on Chihuahua City, Mexico by a ~2 km-class impactor. '
       + 'Used to stress-test mitigation workflows; not an actual NASA impact prediction.',
   },
 }


### PR DESCRIPTION
## Summary
- expand the default impactor diameter to a 2 km-class body and center the UI on Chihuahua City
- update the embedded scenario impactor dimensions, coordinates, and narrative to reflect a direct strike on Chihuahua

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e172a1b7e483318ba01bf19e4252c7