### PR TITLE
Fix critical memory leaks in 3D visualization and map

### DIFF
--- a/src/components/ImpactMap.tsx
+++ b/src/components/ImpactMap.tsx
@@ -29,6 +29,7 @@ export default function ImpactMap({ location, results, onLocationSelect }: Impac
   const impactMarkerRef = useRef<L.Marker | null>(null)
   const devRingRef = useRef<L.Circle | null>(null)
   const craterRingRef = useRef<L.Circle | null>(null)
+  const tileLayerRef = useRef<L.TileLayer | null>(null)
 
   // Initialize map
   useEffect(() => {
@@ -37,21 +38,49 @@ export default function ImpactMap({ location, results, onLocationSelect }: Impac
     const map = L.map(containerRef.current, { worldCopyJump: true }).setView(location, 4)
     mapRef.current = map
 
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 15,
       attribution: '&copy; OpenStreetMap contributors'
-    }).addTo(map)
+    })
+    tileLayer.addTo(map)
+    tileLayerRef.current = tileLayer
 
     // Add click handler
-    map.on('click', (e: L.LeafletMouseEvent) => {
+    const handleClick = (e: L.LeafletMouseEvent) => {
       onLocationSelect(e.latlng.lat, e.latlng.lng)
-    })
+    }
+    map.on('click', handleClick)
 
     // Add initial marker
     const marker = L.marker(location, { title: 'Impact' }).addTo(map)
     impactMarkerRef.current = marker
 
     return () => {
+      // Remove click handler
+      map.off('click', handleClick)
+
+      // Remove all layers
+      if (tileLayerRef.current) {
+        tileLayerRef.current.remove()
+        tileLayerRef.current = null
+      }
+
+      if (impactMarkerRef.current) {
+        impactMarkerRef.current.remove()
+        impactMarkerRef.current = null
+      }
+
+      if (devRingRef.current) {
+        devRingRef.current.remove()
+        devRingRef.current = null
+      }
+
+      if (craterRingRef.current) {
+        craterRingRef.current.remove()
+        craterRingRef.current = null
+      }
+
+      // Remove map instance
       map.remove()
       mapRef.current = null
     }


### PR DESCRIPTION
## Summary
Fixed critical memory leaks in OrbitVisualization and ImpactMap components that were causing memory accumulation during component lifecycle.

## Changes

### OrbitVisualization.tsx
- **Stop animation loop on cleanup**: Added `isRunning` flag and `cancelAnimationFrame` to prevent continued rendering after unmount
- **Dispose Three.js resources**:
  - All geometries (sun, earth orbit, earth marker, asteroid marker, orbit line)
  - All materials (BasicMaterial instances)
  - OrbitControls instance
  - WebGLRenderer
- **Clear event listeners**: Removed resize event listener
- **Clear refs**: Set all refs to null on cleanup

### ImpactMap.tsx
- **Store tile layer**: Added `tileLayerRef` to properly track and dispose OpenStreetMap layer
- **Remove event listeners**: Properly remove click handler with named function reference
- **Dispose Leaflet layers**:
  - Tile layer
  - Impact marker
  - Devastation ring
  - Crater ring
- **Clear refs**: Set all refs to null on cleanup

## Impact
- Prevents memory leaks when navigating away from components
- Reduces browser memory consumption during extended use
- Improves overall application performance
- Fixes issue where old animation loops continued running after component unmount

## Test plan
- [x] Tested in dev environment with HMR
- [ ] Verify no memory leaks in Chrome DevTools Performance Monitor
- [ ] Test component mount/unmount cycles
- [ ] Verify 3D visualization still works correctly
- [ ] Verify map interactions still work correctly