### PR TITLE
Handle missing orbital data gracefully

### DIFF
--- a/src/components/NEOBrowser.tsx
+++ b/src/components/NEOBrowser.tsx
@@ -60,6 +60,11 @@ export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserPr
     }
   }
 
+  const resolveOrbitalData = (neo: NEO): OrbitalData => {
+    const rawOrbitalData = neo.orbital_data ?? FALLBACK_NEO_MAP.get(neo.id)?.orbital_data
+    return parseOrbitalData(rawOrbitalData) ?? getDefaultOrbit()
+  }
+
   const handleSelection = (neo: NEO) => {
     const diameter = neo.estimated_diameter?.meters
     if (diameter) {
@@ -76,7 +81,7 @@ export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserPr
 
     applyScenarioParams(neo)
 
-    const orbitalData = parseOrbitalData(neo.orbital_data) || getDefaultOrbit()
+    const orbitalData = resolveOrbitalData(neo)
     onNEOSelect(neo, orbitalData)
   }
 


### PR DESCRIPTION
## Summary
- guard NEO selection against missing orbital data by reusing cached scenario values or a default orbit

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e1828c31ec8331b1a94f4b8c745931