### PR TITLE
Add type safety for orbital data parsing

### DIFF
--- a/src/components/NEOBrowser.tsx
+++ b/src/components/NEOBrowser.tsx
@@ -61,21 +61,29 @@ export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserPr
   }
 
   const handleSelection = (neo: NEO) => {
+    // Update diameter if available and valid
     const diameter = neo.estimated_diameter?.meters
-    if (diameter) {
+    if (diameter && diameter.estimated_diameter_min >= 0 && diameter.estimated_diameter_max >= 0) {
       const avgDiameter = Math.round(
         (diameter.estimated_diameter_min + diameter.estimated_diameter_max) / 2
       )
-      onParamsUpdate({ diameter: avgDiameter })
+      if (!isNaN(avgDiameter) && avgDiameter > 0) {
+        onParamsUpdate({ diameter: avgDiameter })
+      }
     }
 
+    // Update velocity if available and valid
     const velocity = neo.close_approach_data?.[0]?.relative_velocity?.kilometers_per_second
     if (velocity) {
-      onParamsUpdate({ velocity: Number(velocity) })
+      const velocityNum = Number(velocity)
+      if (!isNaN(velocityNum) && velocityNum > 0) {
+        onParamsUpdate({ velocity: velocityNum })
+      }
     }
 
     applyScenarioParams(neo)
 
+    // Parse orbital data with fallback to default
     const orbitalData = parseOrbitalData(neo.orbital_data) || getDefaultOrbit()
     onNEOSelect(neo, orbitalData)
   }

--- a/src/utils/orbital.ts
+++ b/src/utils/orbital.ts
@@ -7,11 +7,29 @@ const YEAR_S = 365.25 * 86400 // seconds in a Julian year
 export function parseOrbitalData(orbitalDataRaw: any): OrbitalData | null {
   if (!orbitalDataRaw) return null
 
-  const a = Number(orbitalDataRaw.semi_major_axis || 1)
-  const e = Number(orbitalDataRaw.eccentricity || 0.1)
+  // Validate that required fields exist
+  if (!orbitalDataRaw.semi_major_axis || !orbitalDataRaw.eccentricity) {
+    console.warn('Orbital data missing required fields (semi_major_axis or eccentricity)')
+    return null
+  }
+
+  const a = Number(orbitalDataRaw.semi_major_axis)
+  const e = Number(orbitalDataRaw.eccentricity)
   const inc = THREE.MathUtils.degToRad(Number(orbitalDataRaw.inclination || 0))
   const omega = THREE.MathUtils.degToRad(Number(orbitalDataRaw.ascending_node_longitude || 0))
   const w = THREE.MathUtils.degToRad(Number(orbitalDataRaw.perihelion_argument || 0))
+
+  // Validate parsed values are valid numbers
+  if (isNaN(a) || isNaN(e) || isNaN(inc) || isNaN(omega) || isNaN(w)) {
+    console.warn('Orbital data contains invalid numeric values')
+    return null
+  }
+
+  // Validate orbital parameters are physically reasonable
+  if (a <= 0 || e < 0 || e >= 1) {
+    console.warn(`Invalid orbital parameters: a=${a}, e=${e}`)
+    return null
+  }
 
   return { a, e, i: inc, omega, w }
 }


### PR DESCRIPTION
## Summary
Added comprehensive type safety and validation for orbital data parsing to prevent runtime errors from invalid or missing NEO data.

## Changes

### orbital.ts
- **Required field validation**: Check that `semi_major_axis` and `eccentricity` exist before parsing
- **NaN detection**: Validate all parsed numeric values are valid numbers
- **Physical constraints**: Ensure orbital parameters are physically reasonable:
  - Semi-major axis (a) must be > 0
  - Eccentricity (e) must be between 0 and 1 (0 ≤ e < 1)
- **Warning logs**: Added console.warn for debugging invalid data

### NEOBrowser.tsx
- **Diameter validation**: Check diameter values are non-negative before calculation
- **Velocity validation**: Verify velocity is a valid positive number before updating
- **NaN guards**: Prevent NaN values from being passed to parent components

## Impact
- Prevents crashes from malformed NASA NeoWs API responses
- Provides graceful fallbacks when data is missing or invalid
- Improves debugging with specific warning messages
- Ensures only valid numeric values are used in physics calculations

## Test plan
- [x] Tested in dev environment with valid NEO data
- [ ] Verify default orbit is used when orbital data is missing
- [ ] Test with intentionally malformed data
- [ ] Verify console warnings appear for invalid data
- [ ] Check that app doesn't crash with bad API responses