### PR TITLE
Add onboarding tutorial, scenario library, and physics explainers

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,9 +2,10 @@ import type { MouseEventHandler } from 'react'
 
 type HeaderProps = {
   onPreparednessClick: MouseEventHandler<HTMLButtonElement>
+  onTutorialClick: MouseEventHandler<HTMLButtonElement>
 }
 
-export default function Header({ onPreparednessClick }: HeaderProps) {
+export default function Header({ onPreparednessClick, onTutorialClick }: HeaderProps) {
   return (
     <header className="px-6 py-4 border-b border-white/10 sticky top-0 z-[900] panel">
       <div className="max-w-7xl mx-auto flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -17,13 +18,22 @@ export default function Header({ onPreparednessClick }: HeaderProps) {
             </div>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onPreparednessClick}
-          className="self-start rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:border-white/40 hover:bg-white/20"
-        >
-          Impact preparedness guide
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onTutorialClick}
+            className="self-start rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-white/40 hover:bg-white/15"
+          >
+            Launch tutorial
+          </button>
+          <button
+            type="button"
+            onClick={onPreparednessClick}
+            className="self-start rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:border-white/40 hover:bg-white/20"
+          >
+            Impact preparedness guide
+          </button>
+        </div>
       </div>
     </header>
   )

--- a/src/components/ImpactParameters.tsx
+++ b/src/components/ImpactParameters.tsx
@@ -3,6 +3,7 @@ import type { ImpactParams, ImpactResults } from '../types'
 import { calculateImpactResults, formatMass, formatEnergy, formatKm, formatMT } from '../utils/physics'
 import { useLanguage } from '../contexts/LanguageContext'
 import { IMPACT_PARAM_LIMITS } from '../utils/validation'
+import PhysicsTooltip from './PhysicsTooltip'
 
 type NumericField = 'diameter' | 'velocity' | 'density'
 
@@ -85,7 +86,10 @@ export default function ImpactParameters({
       <h2 className="text-base sm:text-lg font-semibold pt-2">{t('impactParams.title')}</h2>
       <div className="grid grid-cols-2 gap-3 text-sm">
         <div>
-          <label className="label block mb-1 text-xs">{t('impactParams.diameter')}</label>
+          <label className="label mb-1 flex items-center gap-1 text-xs">
+            {t('impactParams.diameter')}
+            <PhysicsTooltip term="diameter" />
+          </label>
           <input
             type="number"
             inputMode="decimal"
@@ -109,7 +113,10 @@ export default function ImpactParameters({
           )}
         </div>
         <div>
-          <label className="label block mb-1 text-xs">{t('impactParams.velocity')}</label>
+          <label className="label mb-1 flex items-center gap-1 text-xs">
+            {t('impactParams.velocity')}
+            <PhysicsTooltip term="velocity" />
+          </label>
           <input
             type="number"
             inputMode="decimal"
@@ -133,7 +140,10 @@ export default function ImpactParameters({
           )}
         </div>
         <div>
-          <label className="label block mb-1 text-xs">{t('impactParams.density')}</label>
+          <label className="label mb-1 flex items-center gap-1 text-xs">
+            {t('impactParams.density')}
+            <PhysicsTooltip term="density" />
+          </label>
           <input
             type="number"
             inputMode="decimal"
@@ -157,7 +167,10 @@ export default function ImpactParameters({
           )}
         </div>
         <div>
-          <label className="label block mb-1 text-xs">{t('impactParams.target')}</label>
+          <label className="label mb-1 flex items-center gap-1 text-xs">
+            {t('impactParams.target')}
+            <PhysicsTooltip term="target" />
+          </label>
           <select
             value={params.target}
             onChange={(e) => onParamsChange({ ...params, target: e.target.value as any })}
@@ -181,20 +194,32 @@ export default function ImpactParameters({
       <h2 className="text-base sm:text-lg font-semibold pt-2">{t('impactParams.results')}</h2>
       <div className="grid grid-cols-2 gap-3 text-sm">
         <div className="metric rounded-xl p-3">
-          <div className="label text-xs">{t('impactParams.mass')}</div>
+          <div className="label flex items-center gap-1 text-xs">
+            {t('impactParams.mass')}
+            <PhysicsTooltip term="mass" />
+          </div>
           <div className="text-base sm:text-lg font-semibold">{formatMass(results.mass)}</div>
         </div>
         <div className="metric rounded-xl p-3">
-          <div className="label text-xs">{t('impactParams.energy')}</div>
+          <div className="label flex items-center gap-1 text-xs">
+            {t('impactParams.energy')}
+            <PhysicsTooltip term="energy" />
+          </div>
           <div className="text-base sm:text-lg font-semibold">{formatEnergy(results.energy)}</div>
           <div className="label text-[10px] sm:text-[11px]">{formatMT(results.energyMT)}</div>
         </div>
         <div className="metric rounded-xl p-3">
-          <div className="label text-xs">{t('impactParams.devastation')}</div>
+          <div className="label flex items-center gap-1 text-xs">
+            {t('impactParams.devastation')}
+            <PhysicsTooltip term="devastationRadius" />
+          </div>
           <div className="text-base sm:text-lg font-semibold">{formatKm(results.devastationRadius)}</div>
         </div>
         <div className="metric rounded-xl p-3">
-          <div className="label text-xs">{t('impactParams.crater')}</div>
+          <div className="label flex items-center gap-1 text-xs">
+            {t('impactParams.crater')}
+            <PhysicsTooltip term="craterDiameter" />
+          </div>
           <div className="text-base sm:text-lg font-semibold">{formatKm(results.craterDiameter)}</div>
         </div>
       </div>

--- a/src/components/ImpactScenarioLibrary.tsx
+++ b/src/components/ImpactScenarioLibrary.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import type { ImpactScenario } from '../data/impactScenarios'
+
+interface ImpactScenarioLibraryProps {
+  scenarios: ImpactScenario[]
+  onSelectScenario: (scenario: ImpactScenario) => void
+  className?: string
+}
+
+export default function ImpactScenarioLibrary({
+  scenarios,
+  onSelectScenario,
+  className,
+}: ImpactScenarioLibraryProps) {
+  const [activeId, setActiveId] = useState<string | null>(scenarios[0]?.id ?? null)
+
+  if (scenarios.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={`space-y-3 ${className ?? ''}`.trim()}>
+      <div>
+        <h2 className="text-base sm:text-lg font-semibold">Impact scenario library</h2>
+        <p className="label text-xs">Curated drills and what-if cases built on NASA NeoWs objects.</p>
+      </div>
+      <div className="space-y-2">
+        {scenarios.map((scenario) => {
+          const isActive = scenario.id === activeId
+          const impact = scenario.neo.impact_scenario
+
+          return (
+            <article
+              key={scenario.id}
+              className={`rounded-xl border border-white/10 bg-black/25 transition-colors ${
+                isActive ? 'ring-1 ring-white/30 bg-white/5' : 'hover:bg-white/5'
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => setActiveId((prev) => (prev === scenario.id ? null : scenario.id))}
+                className="w-full px-3 py-3 text-left"
+                aria-expanded={isActive}
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-semibold">{scenario.title}</span>
+                    {impact ? (
+                      <span className="rounded-full bg-red-500/10 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-wide text-red-200">
+                        {impact.probability ? `${Math.round(impact.probability * 1000) / 10}%` : 'Scenario'}
+                      </span>
+                    ) : (
+                      <span className="rounded-full bg-slate-500/20 px-2 py-[2px] text-[10px] uppercase tracking-wide text-slate-200">
+                        Reference
+                      </span>
+                    )}
+                  </div>
+                  <p className="label text-[11px]">{scenario.subtitle}</p>
+                  {impact ? (
+                    <p className="label text-[10px]">
+                      {new Date(impact.impact_date).toUTCString()} • {impact.surface_type} surface
+                    </p>
+                  ) : null}
+                </div>
+              </button>
+              {isActive ? (
+                <div className="space-y-3 border-t border-white/10 px-4 pb-4 text-xs">
+                  <p className="pt-3 leading-snug text-white/90">{scenario.description}</p>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-lg bg-black/40 p-3">
+                      <div className="label text-[10px] uppercase tracking-wide">Timeline</div>
+                      <div className="mt-1 text-[13px] font-semibold text-white">{scenario.timeline}</div>
+                      {impact ? (
+                        <div className="mt-2 text-[11px] text-white/70">
+                          Impact latitude {impact.location[0].toFixed(2)}°, longitude {impact.location[1].toFixed(2)}°
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="rounded-lg bg-black/40 p-3">
+                      <div className="label text-[10px] uppercase tracking-wide">Key parameters</div>
+                      <ul className="mt-1 space-y-1 text-[11px] text-white/80">
+                        <li>Diameter window: {formatDiameterRange(scenario.neo)}</li>
+                        <li>
+                          Modeled velocity:{' '}
+                          {scenario.neo.close_approach_data?.[0]?.relative_velocity?.kilometers_per_second
+                            ? `${Number(
+                                scenario.neo.close_approach_data[0].relative_velocity.kilometers_per_second
+                              ).toFixed(1)} km/s`
+                            : '—'}
+                        </li>
+                        <li>Surface type: {impact?.surface_type ?? '—'}</li>
+                      </ul>
+                    </div>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-lg bg-black/40 p-3">
+                      <div className="label text-[10px] uppercase tracking-wide">Impact storylines</div>
+                      <ul className="mt-1 space-y-1 text-[11px] text-white/80">
+                        {scenario.keyImpacts.map((item) => (
+                          <li key={item} className="flex items-start gap-2">
+                            <span className="mt-[3px] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-white/60" aria-hidden />
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="rounded-lg bg-black/40 p-3">
+                      <div className="label text-[10px] uppercase tracking-wide">Response focus</div>
+                      <ul className="mt-1 space-y-1 text-[11px] text-white/80">
+                        {scenario.focusAreas.map((item) => (
+                          <li key={item} className="flex items-start gap-2">
+                            <span className="mt-[3px] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400/80" aria-hidden />
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="label text-[11px] text-white/70">
+                      Loading a scenario sets the orbit, map focus, and recommended physics parameters.
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => onSelectScenario(scenario)}
+                      className="rounded-full bg-white/10 px-3 py-1.5 text-[12px] font-semibold text-white transition hover:bg-white/20"
+                    >
+                      Load scenario
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </article>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function formatDiameterRange(neo: ImpactScenario['neo']): string {
+  const diameter = neo.estimated_diameter?.meters
+  if (!diameter) return '—'
+  const min = diameter.estimated_diameter_min
+  const max = diameter.estimated_diameter_max
+  if (!min || !max) return '—'
+  if (Math.abs(min - max) < 1) {
+    return `${min.toFixed(0)} m`
+  }
+  return `${min.toFixed(0)}–${max.toFixed(0)} m`
+}

--- a/src/components/NEOScenarioSummary.tsx
+++ b/src/components/NEOScenarioSummary.tsx
@@ -1,6 +1,7 @@
 import type { NEO, ImpactResults } from '../types'
 import { formatEnergy, formatMT, formatKm } from '../utils/physics'
 import type { GeologyAdjustedResults, GeologyAssessment } from '../utils/geology'
+import PhysicsTooltip from './PhysicsTooltip'
 
 interface NEOScenarioSummaryProps {
   neo: NEO | null
@@ -106,13 +107,19 @@ export default function NEOScenarioSummary({
       {impactResults ? (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="metric rounded-lg p-3">
-            <div className="label text-xs">Energy release</div>
-            <div className="text-sm font-semibold">{formatEnergy(impactResults.energy)}</div>
-            <div className="text-[11px] label">{formatMT(impactResults.energyMT)}</div>
+          <div className="label flex items-center gap-1 text-xs">
+            Energy release
+            <PhysicsTooltip term="energy" />
           </div>
-          <div className="metric rounded-lg p-3">
-            <div className="label text-xs">Modeled devastation radius*</div>
-            <div className="text-sm font-semibold">{devastationValue ? formatKm(devastationValue) : '—'}</div>
+          <div className="text-sm font-semibold">{formatEnergy(impactResults.energy)}</div>
+          <div className="text-[11px] label">{formatMT(impactResults.energyMT)}</div>
+        </div>
+        <div className="metric rounded-lg p-3">
+          <div className="label flex items-center gap-1 text-xs">
+            Modeled devastation radius*
+            <PhysicsTooltip term="devastationRadius" />
+          </div>
+          <div className="text-sm font-semibold">{devastationValue ? formatKm(devastationValue) : '—'}</div>
             {geology && adjustedResults ? (
               <div className="text-[11px] label">
                 Terrain multiplier ×{adjustedResults.multipliers.devastation.toFixed(2)}
@@ -123,9 +130,12 @@ export default function NEOScenarioSummary({
               <div className="text-[11px] label">Baseline heuristic</div>
             )}
           </div>
-          <div className="metric rounded-lg p-3 sm:col-span-2">
-            <div className="label text-xs">Crater diameter*</div>
-            <div className="text-sm font-semibold">{craterValue ? formatKm(craterValue) : '—'}</div>
+        <div className="metric rounded-lg p-3 sm:col-span-2">
+          <div className="label flex items-center gap-1 text-xs">
+            Crater diameter*
+            <PhysicsTooltip term="craterDiameter" />
+          </div>
+          <div className="text-sm font-semibold">{craterValue ? formatKm(craterValue) : '—'}</div>
             {geology && adjustedResults ? (
               <div className="text-[11px] label">
                 Surface response ×{adjustedResults.multipliers.crater.toFixed(2)}

--- a/src/components/OnboardingTutorial.tsx
+++ b/src/components/OnboardingTutorial.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react'
+import PhysicsTooltip from './PhysicsTooltip'
+
+interface OnboardingTutorialProps {
+  open: boolean
+  onDismiss: (completed: boolean) => void
+}
+
+const STEPS = [
+  {
+    id: 'neo-browser',
+    title: '1 — Explore real NEO data',
+    description:
+      'Start by selecting a near-Earth object from the NeoWs browser. Scenario tags highlight curated drills like Impactor-2025. Loading a scenario also presets physics inputs.',
+    bullets: [
+      'Use the search bar to filter by designation or nickname.',
+      'Scenario entries inject additional metadata such as impact location and narrative context.',
+      'Switch between English and Spanish via the header toggles.',
+    ],
+  },
+  {
+    id: 'impact-physics',
+    title: '2 — Tune impact physics parameters',
+    description:
+      'Diameter, velocity, density, and surface type feed a fast estimator. Hover over the new physics tooltips to understand how each factor affects energy release and crater size.',
+    bullets: [
+      'Results refresh automatically as you change inputs—no need to mash recalc.',
+      'Terrain intelligence from USGS geology layers adjusts devastation and crater sizing.',
+      'Keep the Preparedness guide handy for checklists and public messaging.',
+    ],
+  },
+  {
+    id: 'visualize',
+    title: '3 — Visualize and brief',
+    description:
+      'The 3D orbit view now includes explainer cards for orbital mechanics. Map rings show devastation vs. crater radius; drag to test alternate impact points or load another scenario.',
+    bullets: [
+      'Orbit cards break down semi-major axis, eccentricity, inclination, and node geometry.',
+      'Use the Impact Scenario Library to brief teams on hazard narratives and response focus.',
+      'Export findings by taking screenshots or piping outputs into downstream planning tools.',
+    ],
+  },
+]
+
+export default function OnboardingTutorial({ open, onDismiss }: OnboardingTutorialProps) {
+  const [stepIndex, setStepIndex] = useState(0)
+
+  useEffect(() => {
+    if (open) {
+      setStepIndex(0)
+    }
+  }, [open])
+
+  if (!open) {
+    return null
+  }
+
+  const step = STEPS[stepIndex]
+  const isLast = stepIndex === STEPS.length - 1
+
+  return (
+    <div className="fixed inset-0 z-[1200] flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/70"
+        aria-hidden
+        onClick={() => onDismiss(false)}
+      />
+      <div className="relative z-[1201] w-full max-w-xl rounded-2xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-sm shadow-2xl">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-white/60">Quickstart tour</p>
+            <h2 className="text-lg font-semibold text-white">{step.title}</h2>
+          </div>
+          <button
+            type="button"
+            onClick={() => onDismiss(false)}
+            className="rounded-full border border-white/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white/70 transition hover:bg-white/10"
+          >
+            Skip
+          </button>
+        </div>
+        <p className="mt-3 text-white/90">{step.description}</p>
+        {step.id === 'impact-physics' ? (
+          <div className="mt-3 flex items-center gap-2 rounded-lg bg-black/40 p-3 text-[11px] text-white/80">
+            <span className="text-[24px] font-semibold text-white/70" aria-hidden>
+              ?
+            </span>
+            <div>
+              <div className="font-semibold text-white/90">Physics tooltips</div>
+              <p>Hover or tap the icon to reveal definitions—try it here:</p>
+              <div className="mt-2 flex items-center gap-2">
+                <span className="label text-[10px] uppercase tracking-wide">Energy</span>
+                <PhysicsTooltip term="energy" />
+                <span className="label text-[10px] uppercase tracking-wide">Crater</span>
+                <PhysicsTooltip term="craterDiameter" />
+              </div>
+            </div>
+          </div>
+        ) : null}
+        <ul className="mt-4 space-y-2">
+          {step.bullets.map((item) => (
+            <li key={item} className="flex items-start gap-2 text-white/80">
+              <span className="mt-[6px] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400" aria-hidden />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-6 flex items-center justify-between text-[11px] uppercase tracking-wide text-white/60">
+          <span>
+            Step {stepIndex + 1} of {STEPS.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setStepIndex((index) => Math.max(0, index - 1))}
+              className="rounded-full border border-white/20 px-3 py-1 text-[11px] font-semibold text-white/70 transition hover:bg-white/10 disabled:opacity-40 disabled:hover:bg-transparent"
+              disabled={stepIndex === 0}
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (isLast) {
+                  onDismiss(true)
+                } else {
+                  setStepIndex((index) => Math.min(STEPS.length - 1, index + 1))
+                }
+              }}
+              className="rounded-full bg-emerald-500/90 px-4 py-1.5 text-[12px] font-semibold text-emerald-50 transition hover:bg-emerald-400"
+            >
+              {isLast ? 'Finish' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/OrbitVisualization.tsx
+++ b/src/components/OrbitVisualization.tsx
@@ -11,6 +11,7 @@ import {
   getDefaultOrbit
 } from '../utils/orbital'
 import { useLanguage } from '../contexts/LanguageContext'
+import OrbitalMechanicsExplainers from './OrbitalMechanicsExplainers'
 
 interface OrbitVisualizationProps {
   orbitalData: OrbitalData | null
@@ -314,6 +315,7 @@ export default function OrbitVisualization({ orbitalData }: OrbitVisualizationPr
         ref={containerRef}
         className="w-full h-64 md:h-80 lg:h-[28rem] rounded-xl border border-white/10"
       />
+      <OrbitalMechanicsExplainers orbitalData={orbitalData} />
     </div>
   )
 }

--- a/src/components/OrbitalMechanicsExplainers.tsx
+++ b/src/components/OrbitalMechanicsExplainers.tsx
@@ -1,0 +1,116 @@
+import type { OrbitalData } from '../types'
+import { getDefaultOrbit } from '../utils/orbital'
+import PhysicsTooltip, { type PhysicsTerm } from './PhysicsTooltip'
+
+interface OrbitalMechanicsExplainersProps {
+  orbitalData: OrbitalData | null
+}
+
+interface ExplainerCard {
+  id: string
+  label: string
+  value: string
+  insight: string
+  term?: PhysicsTerm
+}
+
+const DEG_PER_RAD = 180 / Math.PI
+
+export default function OrbitalMechanicsExplainers({ orbitalData }: OrbitalMechanicsExplainersProps) {
+  const orbit = orbitalData ?? getDefaultOrbit()
+  const inclinationDeg = (orbit.i * DEG_PER_RAD).toFixed(2)
+  const omegaDeg = (orbit.omega * DEG_PER_RAD).toFixed(2)
+  const perihelionDeg = (orbit.w * DEG_PER_RAD).toFixed(2)
+
+  const cards: ExplainerCard[] = [
+    {
+      id: 'semi-major-axis',
+      label: 'Semi-major axis (a)',
+      term: 'semiMajorAxis' as const,
+      value: `${orbit.a.toFixed(3)} AU`,
+      insight:
+        'Controls orbital period. Values above 1 AU spend more time outside Earth’s orbit, increasing warning time between apparitions.',
+    },
+    {
+      id: 'eccentricity',
+      label: 'Eccentricity (e)',
+      term: 'eccentricity' as const,
+      value: orbit.e.toFixed(3),
+      insight:
+        orbit.e < 0.2
+          ? 'Nearly circular trajectory. Velocity changes modestly along the orbit.'
+          : 'Highly elliptical path. Expect slower motion at aphelion and faster, more energetic passes near perihelion.',
+    },
+    {
+      id: 'inclination',
+      label: 'Inclination (i)',
+      term: 'inclination' as const,
+      value: `${inclinationDeg}°`,
+      insight:
+        Number(inclinationDeg) < 5
+          ? 'Low tilt relative to Earth’s orbital plane—good geometry for radar and optical tracking.'
+          : 'Significant tilt can complicate launch windows for mitigation missions and change entry angle.',
+    },
+    {
+      id: 'ascending-node',
+      label: 'Ascending node (Ω)',
+      term: 'ascendingNode' as const,
+      value: `${omegaDeg}°`,
+      insight:
+        'Defines where the object crosses the ecliptic heading north. Aligns evacuation drills with the hemisphere of approach.',
+    },
+    {
+      id: 'perihelion-argument',
+      label: 'Argument of perihelion (ω)',
+      term: 'perihelionArgument' as const,
+      value: `${perihelionDeg}°`,
+      insight:
+        'Describes the point of closest solar approach. Combined with eccentricity it signals seasonal lighting and thermal conditions for the object.',
+    },
+    {
+      id: 'mission-note',
+      label: 'Mission planning cue',
+      value: `${estimateOrbitalPeriod(orbit.a)} year period`,
+      insight:
+        'Use the period to time deflection missions or future observation campaigns. Longer periods reduce revisit opportunities.',
+    },
+  ]
+
+  return (
+    <div className="mt-3 rounded-xl border border-white/10 bg-black/25 p-4 text-xs text-white/80">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-white">Orbital mechanics explainers</h3>
+        <p className="label text-[10px] uppercase tracking-wide">New</p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {cards.map((card) => (
+          <div key={card.id} className="rounded-lg bg-black/40 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-[11px] font-semibold text-white">
+                {card.label}
+              </div>
+              {card.term ? <PhysicsTooltip term={card.term} /> : null}
+            </div>
+            <div className="mt-1 text-base font-semibold text-white">{card.value}</div>
+            <p className="mt-2 text-[11px] text-white/80 leading-snug">{card.insight}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function estimateOrbitalPeriod(a: number): string {
+  // Kepler's third law approximation: P = a^{3/2}
+  const period = Math.pow(Math.abs(a), 1.5)
+  if (!Number.isFinite(period)) {
+    return '—'
+  }
+  if (period < 0.5) {
+    return `${period.toFixed(2)}`
+  }
+  if (period < 5) {
+    return `${period.toFixed(1)}`
+  }
+  return `${period.toFixed(0)}`
+}

--- a/src/components/PhysicsTooltip.tsx
+++ b/src/components/PhysicsTooltip.tsx
@@ -1,0 +1,130 @@
+import { useId, useState } from 'react'
+
+export type PhysicsTerm =
+  | 'diameter'
+  | 'velocity'
+  | 'density'
+  | 'target'
+  | 'mass'
+  | 'energy'
+  | 'devastationRadius'
+  | 'craterDiameter'
+  | 'semiMajorAxis'
+  | 'eccentricity'
+  | 'inclination'
+  | 'ascendingNode'
+  | 'perihelionArgument'
+
+const PHYSICS_TERM_CONTENT: Record<PhysicsTerm, { title: string; description: string; footnote?: string }> = {
+  diameter: {
+    title: 'Diameter',
+    description:
+      'Physical size of the impactor across its widest point. Larger diameters dramatically increase mass and impact energy.',
+  },
+  velocity: {
+    title: 'Velocity',
+    description:
+      'Speed of the object when it strikes the atmosphere, measured in kilometers per second. Impact energy scales with the square of velocity.',
+  },
+  density: {
+    title: 'Material density',
+    description:
+      'Average density of the impactor in kilograms per cubic meter. Metallic bodies pack more mass into the same volume.',
+  },
+  target: {
+    title: 'Target surface',
+    description:
+      'Surface type at the impact point. Softer terrains absorb energy and change crater size compared with hard continental crust.',
+  },
+  mass: {
+    title: 'Mass estimate',
+    description:
+      'Computed from volume and density. Mass determines how much kinetic energy the impactor delivers.',
+  },
+  energy: {
+    title: 'Impact energy',
+    description:
+      'Kinetic energy released upon impact. Reported in joules and equivalent megatons of TNT for comparison.',
+  },
+  devastationRadius: {
+    title: 'Devastation radius',
+    description:
+      'Approximate radius experiencing severe overpressure and thermal effects. Adjusted for terrain response when geology data is available.',
+  },
+  craterDiameter: {
+    title: 'Crater diameter',
+    description:
+      'Estimated final rim-to-rim size of the crater based on scaling laws for transient crater growth and collapse.',
+  },
+  semiMajorAxis: {
+    title: 'Semi-major axis (a)',
+    description:
+      'Average orbital size measured from the center of the ellipse. It sets the length of an orbital year via Kepler’s third law.',
+  },
+  eccentricity: {
+    title: 'Eccentricity (e)',
+    description:
+      'Shape of the orbit. Values near 0 are circular; larger values stretch the ellipse and create long, slow aphelion passages.',
+  },
+  inclination: {
+    title: 'Inclination (i)',
+    description:
+      'Tilt of the orbital plane relative to Earth’s orbital plane. Higher inclinations mean the object approaches from above or below the ecliptic.',
+  },
+  ascendingNode: {
+    title: 'Longitude of ascending node (Ω)',
+    description:
+      'Points to where the object crosses the ecliptic heading north. Combined with inclination, it locates the orbital plane in space.',
+  },
+  perihelionArgument: {
+    title: 'Argument of perihelion (ω)',
+    description:
+      'Angle from the ascending node to perihelion along the orbit. It tells you where the closest approach to the Sun occurs.',
+  },
+}
+
+interface PhysicsTooltipProps {
+  term: PhysicsTerm
+  className?: string
+}
+
+export default function PhysicsTooltip({ term, className }: PhysicsTooltipProps) {
+  const [open, setOpen] = useState(false)
+  const id = useId()
+  const content = PHYSICS_TERM_CONTENT[term]
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <span
+      className={`relative inline-flex ${className ?? ''}`.trim()}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-describedby={id}
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-white/10 text-[10px] font-semibold text-white/80 transition-colors hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        i
+      </button>
+      <div
+        role="tooltip"
+        id={id}
+        className={`pointer-events-none absolute z-50 w-64 max-w-[18rem] rounded-lg border border-white/20 bg-black/90 p-3 text-left text-[11px] leading-snug text-white shadow-xl transition-opacity duration-150 ${
+          open ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 -translate-y-1'
+        }`}
+        style={{ top: '125%', right: 0 }}
+      >
+        <div className="text-[12px] font-semibold mb-1">{content.title}</div>
+        <p>{content.description}</p>
+        {content.footnote ? <p className="mt-2 text-[10px] text-white/70">{content.footnote}</p> : null}
+      </div>
+    </span>
+  )
+}

--- a/src/data/impactScenarios.ts
+++ b/src/data/impactScenarios.ts
@@ -1,0 +1,233 @@
+import type { ImpactParams, NEO } from '../types'
+import { IMPACTOR_2025, FALLBACK_NEO_MAP } from './scenarioNeos'
+
+export interface ImpactScenario {
+  id: string
+  title: string
+  subtitle: string
+  description: string
+  timeline: string
+  keyImpacts: string[]
+  focusAreas: string[]
+  neo: NEO
+  paramOverrides?: Partial<ImpactParams>
+}
+
+const apophisTemplate: NEO =
+  FALLBACK_NEO_MAP.get('99942') ?? {
+    id: '99942',
+    name: '99942 Apophis',
+    is_potentially_hazardous_asteroid: true,
+    estimated_diameter: {
+      meters: {
+        estimated_diameter_min: 340,
+        estimated_diameter_max: 370,
+      },
+    },
+    orbital_data: {
+      semi_major_axis: '0.922',
+      eccentricity: '0.191',
+      inclination: '3.331',
+      ascending_node_longitude: '204.45',
+      perihelion_argument: '126.4',
+    },
+    close_approach_data: [
+      {
+        close_approach_date: '2029-04-13',
+        relative_velocity: {
+          kilometers_per_second: '7.42',
+        },
+      },
+    ],
+  }
+
+const bennuTemplate: NEO =
+  FALLBACK_NEO_MAP.get('101955') ?? {
+    id: '101955',
+    name: '101955 Bennu (1999 RQ36)',
+    is_potentially_hazardous_asteroid: true,
+    estimated_diameter: {
+      meters: {
+        estimated_diameter_min: 480,
+        estimated_diameter_max: 511,
+      },
+    },
+    orbital_data: {
+      semi_major_axis: '1.1264',
+      eccentricity: '0.2037',
+      inclination: '6.034',
+      ascending_node_longitude: '2.0608',
+      perihelion_argument: '66.2231',
+    },
+    close_approach_data: [
+      {
+        close_approach_date: '2135-09-24',
+        relative_velocity: {
+          kilometers_per_second: '12.7',
+        },
+      },
+    ],
+  }
+
+export const IMPACTOR_2025_SCENARIO: ImpactScenario = {
+  id: 'impactor-2025',
+  title: 'Impactor-2025 city strike drill',
+  subtitle: 'High-energy continental impact with limited warning time',
+  description:
+    'Baseline scenario for the application: Impactor-2025 is inserted into NeoWs listings to stress-test multi-agency coordination for a direct strike on Chihuahua City, Mexico.',
+  timeline: '17 October 2025 • 3-day late warning',
+  keyImpacts: [
+    'Urban core destruction and trans-border supply-chain disruption',
+    'Thermal pulse and blast wave affecting 3+ million residents',
+    'Regional seismic shaking impacting oil & gas infrastructure',
+  ],
+  focusAreas: [
+    'Cross-border emergency coordination between Mexico and the United States',
+    'Prioritization of resilient communications and power restoration',
+    'Rapid deployment of international urban search and rescue teams',
+  ],
+  neo: IMPACTOR_2025,
+  paramOverrides: {
+    density: IMPACTOR_2025.impact_scenario?.material_density,
+    target: IMPACTOR_2025.impact_scenario?.surface_type,
+  },
+}
+
+const apophisScenario: ImpactScenario = {
+  id: 'apophis-drill',
+  title: 'Apophis 2029 coastal impact drill',
+  subtitle: 'Low-probability but high-consequence strike during the 2029 flyby',
+  description:
+    'Planetary defense teams exercise an Apophis deflection failure that redirects the asteroid toward the northeastern Pacific. Coastal megacities drill for tsunami sequencing and mass evacuation.',
+  timeline: '13 April 2029 (UTC) • simulated wave arrival 25–45 minutes post-impact',
+  keyImpacts: [
+    'Modeled ocean entry ~400 km off the U.S. West Coast',
+    'Primary hazards: tsunami run-up and coastal infrastructure collapse',
+    'Secondary hazards: atmospheric shock damage to offshore assets',
+  ],
+  focusAreas: [
+    'Validate evacuation timing and blue water fleet dispersal',
+    'Test international alert coordination across the Pacific Rim',
+    'Assess maritime debris fields for port re-entry planning',
+  ],
+  neo: {
+    ...apophisTemplate,
+    impact_scenario: {
+      probability: 0.002,
+      impact_date: '2029-04-13T22:15:00Z',
+      location: [41.5, -127.4],
+      surface_type: 'oceanic',
+      material_density: 3000,
+      narrative:
+        'Training scenario: Apophis deflection failure results in a deep-water impact in the Cascadia Subduction Zone, triggering a trans-Pacific tsunami response.',
+    },
+  },
+  paramOverrides: {
+    density: 3000,
+    target: 'oceanic',
+  },
+}
+
+const bennuScenario: ImpactScenario = {
+  id: 'bennu-2135',
+  title: 'Bennu 2135 corridor watch',
+  subtitle: 'Far-term monitoring of keyhole passages and contingency payloads',
+  description:
+    'Analysts test rapid catalog updates and kinetic impactor deployment timelines if Bennu passes through a 2135 gravitational keyhole that sets up a late-2100s impact trajectory.',
+  timeline: '24 September 2135 • 60-year observational campaign horizon',
+  keyImpacts: [
+    'High-precision tracking required to resolve keyhole entry risk',
+    'Long-lead mission planning with multiple launch windows',
+    'Community preparedness messaging for a multigenerational threat',
+  ],
+  focusAreas: [
+    'Compare kinetic impactor and gravity tractor mission architectures',
+    'Model policy triggers for transitioning from monitoring to mitigation',
+    'Develop archival data products for future planetary defense teams',
+  ],
+  neo: {
+    ...bennuTemplate,
+    impact_scenario: {
+      probability: 0.0001,
+      impact_date: '2189-09-12T08:00:00Z',
+      location: [32.1, -98.6],
+      surface_type: 'continental',
+      material_density: 1260,
+      narrative:
+        'Strategic planning exercise: Bennu threads a 2135 keyhole leading to a late-century land impact over North America. Used to evaluate readiness for decades-long mitigation campaigns.',
+    },
+  },
+  paramOverrides: {
+    density: 1260,
+    target: 'continental',
+  },
+}
+
+const didymosScenarioNeo: NEO = {
+  id: '65803',
+  name: '65803 Didymos system',
+  estimated_diameter: {
+    meters: {
+      estimated_diameter_min: 780,
+      estimated_diameter_max: 820,
+    },
+  },
+  is_potentially_hazardous_asteroid: true,
+  orbital_data: {
+    semi_major_axis: '1.644',
+    eccentricity: '0.383',
+    inclination: '3.4',
+    ascending_node_longitude: '73.2',
+    perihelion_argument: '319.3',
+  },
+  close_approach_data: [
+    {
+      close_approach_date: '2182-10-04',
+      relative_velocity: {
+        kilometers_per_second: '23.6',
+      },
+    },
+  ],
+  impact_scenario: {
+    probability: 0.05,
+    impact_date: '2182-10-04T15:30:00Z',
+    location: [-23.8, 134.2],
+    surface_type: 'continental',
+    material_density: 2400,
+    narrative:
+      'What-if follow-up to the DART demonstration: an unmitigated Didymos trajectory intersects central Australia, used to explore coordinated evacuation of sparse populations and mining infrastructure hardening.',
+  },
+}
+
+const didymosScenario: ImpactScenario = {
+  id: 'didymos-contingency',
+  title: 'Didymos contingency planning',
+  subtitle: 'Translating kinetic impact test data into full-scale response playbooks',
+  description:
+    'Emergency managers extrapolate from the DART kinetic impact test to rehearse a future Didymos-class object on a collision course with remote communities and mineral operations.',
+  timeline: '4 October 2182 • 6-hour warning-to-impact window',
+  keyImpacts: [
+    'Short-notice evacuation logistics for remote settlements',
+    'Protection of critical mineral supply chains and communications links',
+    'Post-impact dust loading and atmospheric recovery scenarios',
+  ],
+  focusAreas: [
+    'Use real DART data to tune impact physics assumptions',
+    'Integrate satellite-derived mineral maps for infrastructure triage',
+    'Coordinate with aviation authorities for rapid airspace clearance',
+  ],
+  neo: didymosScenarioNeo,
+  paramOverrides: {
+    density: 2400,
+    target: 'continental',
+  },
+}
+
+export const ORDERED_IMPACT_SCENARIOS: ImpactScenario[] = [
+  IMPACTOR_2025_SCENARIO,
+  apophisScenario,
+  bennuScenario,
+  didymosScenario,
+]
+
+export const IMPACT_SCENARIOS = ORDERED_IMPACT_SCENARIOS


### PR DESCRIPTION
## Summary
- add reusable physics tooltip component and surface key definitions in the impact parameter and scenario views
- introduce a curated impact scenario library backed by structured scenario metadata and tie it into the main workflow
- ship an onboarding tutorial plus orbital mechanics explainer cards to guide new users and clarify the 3D visualization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18c8c9f0483319da095f976d056ca