### PR TITLE
Expand impact result metrics with socio-economic modeling

### DIFF
--- a/src/components/ImpactParameters.tsx
+++ b/src/components/ImpactParameters.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react'
 import type { ImpactParams, ImpactResults } from '../types'
-import { calculateImpactResults, formatMass, formatEnergy, formatKm, formatMT } from '../utils/physics'
+import {
+  calculateImpactResults,
+  formatMass,
+  formatEnergy,
+  formatKm,
+  formatMT,
+  formatPopulation,
+  formatCurrency,
+  formatYears,
+  formatIndex
+} from '../utils/physics'
 import { useLanguage } from '../contexts/LanguageContext'
 import { IMPACT_PARAM_LIMITS } from '../utils/validation'
 import PhysicsTooltip from './PhysicsTooltip'
@@ -221,6 +231,80 @@ export default function ImpactParameters({
             <PhysicsTooltip term="craterDiameter" />
           </div>
           <div className="text-base sm:text-lg font-semibold">{formatKm(results.craterDiameter)}</div>
+        </div>
+      </div>
+
+      <h3 className="text-base sm:text-lg font-semibold pt-4">{t('impactParams.population.title')}</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 text-sm">
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.population.exposed')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatPopulation(results.population.exposed)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.population.displaced')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatPopulation(results.population.displaced)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.population.fatalities')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatPopulation(results.population.fatalities)}</div>
+        </div>
+      </div>
+
+      <h3 className="text-base sm:text-lg font-semibold pt-4">{t('impactParams.economic.title')}</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 text-sm">
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.economic.directDamage')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatCurrency(results.economic.directDamage)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.economic.infrastructureLoss')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatCurrency(results.economic.infrastructureLoss)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.economic.recovery')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatYears(results.economic.recoveryYears)}</div>
+        </div>
+      </div>
+
+      <h3 className="text-base sm:text-lg font-semibold pt-4">{t('impactParams.environmental.title')}</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-4 text-sm">
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.environmental.severity')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatIndex(results.environmental.severityIndex)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.environmental.air')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatIndex(results.environmental.airQualityIndex)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.environmental.water')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatIndex(results.environmental.waterQualityIndex)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.environmental.category.label')}</div>
+          <div className="text-base sm:text-lg font-semibold">
+            {t(`impactParams.environmental.category.${results.environmental.category}`)}
+          </div>
+        </div>
+      </div>
+
+      <h3 className="text-base sm:text-lg font-semibold pt-4">{t('impactParams.multiImpact.title')}</h3>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 text-sm">
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.multiImpact.classification')}</div>
+          <div className="text-base sm:text-lg font-semibold">
+            {t(`impactParams.multiImpact.level.${results.multiImpact.classification}`)}
+          </div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.multiImpact.risk')}</div>
+          <div className="text-base sm:text-lg font-semibold">{formatIndex(results.multiImpact.cascadingRisk)}</div>
+        </div>
+        <div className="metric rounded-xl p-3">
+          <div className="label text-xs">{t('impactParams.multiImpact.response')}</div>
+          <div className="text-base sm:text-lg font-semibold">
+            {t(`impactParams.multiImpact.responseLevel.${results.multiImpact.responseLevel}`)}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/NEOScenarioSummary.tsx
+++ b/src/components/NEOScenarioSummary.tsx
@@ -1,5 +1,12 @@
 import type { NEO, ImpactResults } from '../types'
-import { formatEnergy, formatMT, formatKm } from '../utils/physics'
+import {
+  formatEnergy,
+  formatMT,
+  formatKm,
+  formatPopulation,
+  formatCurrency,
+  formatIndex
+} from '../utils/physics'
 import type { GeologyAdjustedResults, GeologyAssessment } from '../utils/geology'
 import PhysicsTooltip from './PhysicsTooltip'
 
@@ -23,6 +30,25 @@ const formatProbability = (value?: number) => {
   if (value === undefined) return 'Unknown'
   return `${Math.round(value * 100)}%`
 }
+
+const cascadeLabels = {
+  localized: 'Localized',
+  regional: 'Regional',
+  global: 'Global'
+} as const
+
+const responseLabels = {
+  monitor: 'Monitor & inform',
+  coordinate: 'Coordinate regionally',
+  mobilize: 'Mobilize internationally'
+} as const
+
+const categoryLabels = {
+  minimal: 'Minimal',
+  moderate: 'Moderate',
+  severe: 'Severe',
+  extreme: 'Extreme'
+} as const
 
 export default function NEOScenarioSummary({
   neo,
@@ -128,8 +154,8 @@ export default function NEOScenarioSummary({
               <div className="text-[11px] label">Geology profile {geology.profile.label}</div>
             ) : (
               <div className="text-[11px] label">Baseline heuristic</div>
-            )}
-          </div>
+          )}
+        </div>
         <div className="metric rounded-lg p-3 sm:col-span-2">
           <div className="label flex items-center gap-1 text-xs">
             Crater diameter*
@@ -160,6 +186,33 @@ export default function NEOScenarioSummary({
               ) : null}
             </div>
           ) : null}
+          <div className="metric rounded-lg p-3">
+            <div className="label text-xs">Population exposed</div>
+            <div className="text-sm font-semibold">{formatPopulation(impactResults.population.exposed)}</div>
+            <div className="text-[11px] label">Displaced {formatPopulation(impactResults.population.displaced)}</div>
+          </div>
+          <div className="metric rounded-lg p-3">
+            <div className="label text-xs">Economic loss</div>
+            <div className="text-sm font-semibold">{formatCurrency(impactResults.economic.directDamage)}</div>
+            <div className="text-[11px] label">Infrastructure {formatCurrency(impactResults.economic.infrastructureLoss)}</div>
+          </div>
+          <div className="metric rounded-lg p-3">
+            <div className="label text-xs">Environmental severity</div>
+            <div className="text-sm font-semibold">{formatIndex(impactResults.environmental.severityIndex)}</div>
+            <div className="text-[11px] label">
+              Category {categoryLabels[impactResults.environmental.category]}
+            </div>
+          </div>
+          <div className="metric rounded-lg p-3">
+            <div className="label text-xs">Cascade outlook</div>
+            <div className="text-sm font-semibold">
+              {cascadeLabels[impactResults.multiImpact.classification]} cascade
+            </div>
+            <div className="text-[11px] label">
+              Risk {formatIndex(impactResults.multiImpact.cascadingRisk)} • Response{' '}
+              {responseLabels[impactResults.multiImpact.responseLevel]}
+            </div>
+          </div>
         </div>
       ) : (
         <p className="text-xs label">Adjust parameters to compute energy release and crater size.</p>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -78,6 +78,47 @@ const translations: Record<Language, any> = {
       energy: 'Impact Energy',
       devastation: 'Devastation Radius',
       crater: 'Crater Diameter',
+      population: {
+        title: 'Population Impact',
+        exposed: 'Population exposed',
+        displaced: 'Potentially displaced',
+        fatalities: 'Projected fatalities'
+      },
+      economic: {
+        title: 'Economic Damage',
+        directDamage: 'Direct damage',
+        infrastructureLoss: 'Infrastructure loss',
+        recovery: 'Recovery timeline'
+      },
+      environmental: {
+        title: 'Environmental Consequences',
+        severity: 'Overall severity',
+        air: 'Air quality impact',
+        water: 'Water impact',
+        category: {
+          label: 'Impact category',
+          minimal: 'Minimal',
+          moderate: 'Moderate',
+          severe: 'Severe',
+          extreme: 'Extreme'
+        }
+      },
+      multiImpact: {
+        title: 'Multi-impact Scenario',
+        classification: 'Cascade classification',
+        risk: 'Cascading risk score',
+        response: 'Suggested coordination level',
+        level: {
+          localized: 'Localized',
+          regional: 'Regional',
+          global: 'Global'
+        },
+        responseLevel: {
+          monitor: 'Monitor & inform',
+          coordinate: 'Coordinate regional response',
+          mobilize: 'Mobilize international resources'
+        }
+      },
       validation: {
         required: 'Please enter a value.',
         number: 'Enter a valid number.',
@@ -130,6 +171,47 @@ const translations: Record<Language, any> = {
       energy: 'Energía de Impacto',
       devastation: 'Radio de Devastación',
       crater: 'Diámetro del Cráter',
+      population: {
+        title: 'Impacto en la Población',
+        exposed: 'Población expuesta',
+        displaced: 'Potencialmente desplazados',
+        fatalities: 'Fatalidades proyectadas'
+      },
+      economic: {
+        title: 'Daño Económico',
+        directDamage: 'Daño directo',
+        infrastructureLoss: 'Pérdida en infraestructura',
+        recovery: 'Cronograma de recuperación'
+      },
+      environmental: {
+        title: 'Consecuencias Ambientales',
+        severity: 'Severidad total',
+        air: 'Impacto en la calidad del aire',
+        water: 'Impacto hídrico',
+        category: {
+          label: 'Categoría de impacto',
+          minimal: 'Mínima',
+          moderate: 'Moderada',
+          severe: 'Severa',
+          extreme: 'Extrema'
+        }
+      },
+      multiImpact: {
+        title: 'Escenario Multimpacto',
+        classification: 'Clasificación de cascada',
+        risk: 'Puntaje de riesgo en cascada',
+        response: 'Nivel sugerido de coordinación',
+        level: {
+          localized: 'Localizado',
+          regional: 'Regional',
+          global: 'Global'
+        },
+        responseLevel: {
+          monitor: 'Monitorear e informar',
+          coordinate: 'Coordinar respuesta regional',
+          mobilize: 'Movilizar recursos internacionales'
+        }
+      },
       validation: {
         required: 'Ingresa un valor.',
         number: 'Ingresa un número válido.',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,12 +7,45 @@ export interface ImpactParams {
   target: SurfaceType
 }
 
+export type ImpactSeverityCategory = 'minimal' | 'moderate' | 'severe' | 'extreme'
+export type ImpactCascadeLevel = 'localized' | 'regional' | 'global'
+export type ResponseLevel = 'monitor' | 'coordinate' | 'mobilize'
+
+export interface PopulationImpact {
+  exposed: number  // people
+  displaced: number  // people
+  fatalities: number  // people
+}
+
+export interface EconomicImpact {
+  directDamage: number  // USD
+  infrastructureLoss: number  // USD
+  recoveryYears: number  // years
+}
+
+export interface EnvironmentalImpact {
+  severityIndex: number  // 0-100 scale
+  airQualityIndex: number  // 0-100 scale
+  waterQualityIndex: number  // 0-100 scale
+  category: ImpactSeverityCategory
+}
+
+export interface MultiImpactScenario {
+  classification: ImpactCascadeLevel
+  cascadingRisk: number  // 0-100 scale
+  responseLevel: ResponseLevel
+}
+
 export interface ImpactResults {
   mass: number  // kg
   energy: number  // joules
   energyMT: number  // megatons TNT
   devastationRadius: number  // km
   craterDiameter: number  // km
+  population: PopulationImpact
+  economic: EconomicImpact
+  environmental: EnvironmentalImpact
+  multiImpact: MultiImpactScenario
 }
 
 export interface NEO {

--- a/src/utils/physics.ts
+++ b/src/utils/physics.ts
@@ -1,7 +1,55 @@
-import type { ImpactParams, ImpactResults } from '../types'
+import type {
+  ImpactParams,
+  ImpactResults,
+  ImpactSeverityCategory,
+  ImpactCascadeLevel,
+  ResponseLevel
+} from '../types'
+
+const TARGET_FACTORS = {
+  continental: {
+    populationDensity: 380, // people per km^2
+    gdpDensity: 1.6e9, // USD per km^2
+    envSensitivity: 0.9,
+    displacementFactor: 0.65
+  },
+  sedimentary: {
+    populationDensity: 180,
+    gdpDensity: 1.1e9,
+    envSensitivity: 1.1,
+    displacementFactor: 0.55
+  },
+  oceanic: {
+    populationDensity: 12,
+    gdpDensity: 0.45e9,
+    envSensitivity: 1.4,
+    displacementFactor: 0.35
+  }
+} as const
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
+
+const classifyEnvironmental = (severity: number): ImpactSeverityCategory => {
+  if (severity >= 85) return 'extreme'
+  if (severity >= 65) return 'severe'
+  if (severity >= 40) return 'moderate'
+  return 'minimal'
+}
+
+const classifyCascade = (score: number): ImpactCascadeLevel => {
+  if (score >= 75) return 'global'
+  if (score >= 45) return 'regional'
+  return 'localized'
+}
+
+const classifyResponse = (score: number): ResponseLevel => {
+  if (score >= 80) return 'mobilize'
+  if (score >= 45) return 'coordinate'
+  return 'monitor'
+}
 
 export function calculateImpactResults(params: ImpactParams): ImpactResults {
-  const { diameter, velocity, density } = params
+  const { diameter, velocity, density, target } = params
 
   // Calculate mass (sphere volume * density)
   const radius = diameter / 2
@@ -21,12 +69,68 @@ export function calculateImpactResults(params: ImpactParams): ImpactResults {
   // Heuristic crater diameter (km)
   const craterDiameter = 1.1 * Math.pow(energyMT, 0.25)
 
+  const devastationArea = Math.PI * Math.pow(devastationRadius, 2) // km^2
+  const factors = TARGET_FACTORS[target]
+
+  const exposedPopulation = devastationArea * factors.populationDensity
+  const fatalityRate = clamp(0.08 + Math.pow(energyMT, 0.28) / 25, 0.02, 0.4)
+  const displacedRate = clamp(factors.displacementFactor + fatalityRate / 2, 0.15, 0.85)
+
+  const fatalities = exposedPopulation * fatalityRate
+  const displaced = exposedPopulation * displacedRate
+
+  const energySeverity = Math.pow(energyMT, 0.36)
+  const economicScalar = clamp(0.75 + energySeverity / 18, 0.8, 3)
+  const directDamage = devastationArea * factors.gdpDensity * economicScalar
+  const infrastructureLoss = directDamage * clamp(0.35 + energySeverity / 30, 0.4, 0.85)
+  const recoveryYears = clamp(1.5 + energySeverity / 6, 0.5, 25)
+
+  const baseEnv = clamp(Math.pow(energyMT, 0.32) * 18, 5, 110)
+  const severityIndex = clamp(baseEnv * factors.envSensitivity, 0, 100)
+  const airQualityIndex = clamp(severityIndex * (target === 'continental' ? 1.05 : 0.9), 0, 100)
+  const waterQualityIndex = clamp(
+    severityIndex * (target === 'oceanic' ? 1.2 : target === 'sedimentary' ? 1.0 : 0.85),
+    0,
+    100
+  )
+  const environmentalCategory = classifyEnvironmental(severityIndex)
+
+  const cascadeBase = clamp(
+    (exposedPopulation / 1_000_000) * 9 + (directDamage / 1e12) * 14 + severityIndex * 0.45,
+    0,
+    120
+  )
+  const cascadingRisk = clamp(cascadeBase, 0, 100)
+  const cascadeClassification = classifyCascade(cascadingRisk)
+  const responseLevel = classifyResponse(cascadingRisk)
+
   return {
     mass,
     energy,
     energyMT,
     devastationRadius,
-    craterDiameter
+    craterDiameter,
+    population: {
+      exposed: exposedPopulation,
+      displaced,
+      fatalities
+    },
+    economic: {
+      directDamage,
+      infrastructureLoss,
+      recoveryYears
+    },
+    environmental: {
+      severityIndex,
+      airQualityIndex,
+      waterQualityIndex,
+      category: environmentalCategory
+    },
+    multiImpact: {
+      classification: cascadeClassification,
+      cascadingRisk,
+      responseLevel
+    }
   }
 }
 
@@ -54,4 +158,28 @@ export function formatKm(value: number): string {
 export function formatMT(value: number): string {
   const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 })
   return `${fmt.format(value)} Mt TNT`
+}
+
+export function formatPopulation(value: number): string {
+  const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+  return fmt.format(Math.round(value))
+}
+
+export function formatCurrency(value: number): string {
+  const fmt = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  })
+  return fmt.format(Math.round(value))
+}
+
+export function formatYears(value: number): string {
+  const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 })
+  return `${fmt.format(value)} yrs`
+}
+
+export function formatIndex(value: number): string {
+  const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+  return `${fmt.format(value)} / 100`
 }


### PR DESCRIPTION
## Summary
- extend impact physics calculations to estimate population, economic, environmental, and cascading impact metrics
- display the new consequence data in both the impact parameter dashboard and the NEO scenario summary
- add localization strings and formatting helpers for the additional impact insights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e190e22c74833189d7422bf9790706