### PR TITLE
Add theme and language switchers to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import type { MouseEventHandler } from 'react'
+import ThemeSwitcher from './ThemeSwitcher'
+import LanguageSwitcher from './LanguageSwitcher'
 
 type HeaderProps = {
   onPreparednessClick: MouseEventHandler<HTMLButtonElement>
@@ -19,6 +21,8 @@ export default function Header({ onPreparednessClick, onTutorialClick }: HeaderP
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <LanguageSwitcher />
+          <ThemeSwitcher />
           <button
             type="button"
             onClick={onTutorialClick}


### PR DESCRIPTION
## Summary
- Added `ThemeSwitcher` component to header for dark/light theme toggle
- Added `LanguageSwitcher` component to header for EN/ES language switching
- Both switchers positioned before tutorial and preparedness buttons

## Test plan
- [x] Theme switcher appears in header
- [x] Language switcher appears in header
- [x] Both switchers function correctly
- [x] Responsive layout maintained on mobile devices