### PR TITLE
Add export and sharing workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "impactor-2025",
       "version": "1.0.0",
       "dependencies": {
+        "html2canvas": "^1.4.1",
+        "jspdf": "^3.0.3",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1597,7 +1599,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2950,12 +2951,25 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.25",
@@ -3009,7 +3023,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/webxr": {
@@ -3558,6 +3572,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
@@ -3736,6 +3759,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3845,6 +3888,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.45.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
@@ -3882,6 +3937,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -4042,6 +4106,16 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4592,6 +4666,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5108,6 +5193,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5185,6 +5283,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -5795,6 +5899,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6219,6 +6346,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6292,6 +6425,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6560,6 +6700,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6671,6 +6821,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6780,6 +6937,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -7177,6 +7344,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7469,6 +7646,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
@@ -7561,6 +7748,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -7944,6 +8140,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.6",

--- a/package.json
+++ b/package.json
@@ -10,27 +10,29 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
+    "jspdf": "^3.0.3",
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "three": "^0.160.0",
-    "leaflet": "^1.9.4"
+    "three": "^0.160.0"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.8",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.160.0",
-    "@types/leaflet": "^1.9.8",
-    "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.5",
-    "vite-plugin-pwa": "^0.21.1",
-    "tailwindcss": "^3.4.17",
-    "postcss": "^8.4.49",
-    "autoprefixer": "^10.4.20",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.4.14"
+    "eslint-plugin-react-refresh": "^0.4.14",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.5",
+    "vite-plugin-pwa": "^0.21.1"
   }
 }

--- a/src/components/ExportSharePanel.tsx
+++ b/src/components/ExportSharePanel.tsx
@@ -1,0 +1,338 @@
+import { useMemo, useState } from 'react'
+import { jsPDF } from 'jspdf'
+import type { ImpactParams, ImpactResults, NEO, OrbitalData } from '../types'
+import type { GeologyAdjustedResults, GeologyAssessment } from '../utils/geology'
+import { currentShareUrl } from '../utils/sharing'
+import type { ImpactMapHandle } from './ImpactMap'
+import type { OrbitVisualizationHandle } from './OrbitVisualization'
+
+interface ExportSharePanelProps {
+  neo: NEO | null
+  impactParams: ImpactParams
+  impactResults: ImpactResults | null
+  adjustedResults: GeologyAdjustedResults | null
+  geology: GeologyAssessment | null
+  location: [number, number]
+  orbitalData: OrbitalData | null
+  orbitHandle: OrbitVisualizationHandle | null
+  mapHandle: ImpactMapHandle | null
+}
+
+const formatNumber = (value: number | null | undefined, unit?: string) => {
+  if (value == null || Number.isNaN(value)) {
+    return '—'
+  }
+  const formatted = value.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: value < 10 ? 2 : 0,
+  })
+  return unit ? `${formatted} ${unit}` : formatted
+}
+
+const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+export default function ExportSharePanel({
+  neo,
+  impactParams,
+  impactResults,
+  adjustedResults,
+  geology,
+  location,
+  orbitalData,
+  orbitHandle,
+  mapHandle,
+}: ExportSharePanelProps) {
+  const [status, setStatus] = useState<string | null>(null)
+
+  const shareUrl = useMemo(() => {
+    if (!neo) {
+      return null
+    }
+    return currentShareUrl({
+      neoId: neo.id,
+      params: impactParams,
+      location,
+    })
+  }, [neo, impactParams, location])
+
+  const resetStatusLater = () => {
+    window.setTimeout(() => setStatus(null), 4000)
+  }
+
+  const handleCopyShareLink = async () => {
+    if (!shareUrl) {
+      setStatus('Select a NEO to generate shareable links.')
+      resetStatusLater()
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setStatus('Scenario link copied to clipboard!')
+    } catch (error) {
+      console.error('Clipboard copy failed', error)
+      setStatus('Copy failed. You can manually copy the URL from your browser.')
+    }
+    resetStatusLater()
+  }
+
+  const handleGeneratePdf = () => {
+    if (!neo) {
+      setStatus('Select a NEO before exporting a report.')
+      resetStatusLater()
+      return
+    }
+
+    const doc = new jsPDF()
+    let y = 12
+
+    doc.setFontSize(16)
+    doc.text('Impactor-2025 Scenario Report', 12, y)
+
+    doc.setFontSize(11)
+    y += 8
+    doc.text(`Object: ${neo.name}`, 12, y)
+    y += 6
+    doc.text(`Impact site: ${location[0].toFixed(2)}°, ${location[1].toFixed(2)}°`, 12, y)
+
+    y += 8
+    doc.setFontSize(13)
+    doc.text('Impact Parameters', 12, y)
+    doc.setFontSize(10)
+    y += 6
+    doc.text(`Diameter: ${formatNumber(impactParams.diameter, 'm')}`, 14, y)
+    y += 5
+    doc.text(`Velocity: ${formatNumber(impactParams.velocity, 'km/s')}`, 14, y)
+    y += 5
+    doc.text(`Density: ${formatNumber(impactParams.density, 'kg/m³')}`, 14, y)
+    y += 5
+    doc.text(`Surface: ${impactParams.target}`, 14, y)
+
+    if (impactResults) {
+      y += 8
+      doc.setFontSize(13)
+      doc.text('Impact Results', 12, y)
+      doc.setFontSize(10)
+      y += 6
+      doc.text(`Energy: ${formatNumber(impactResults.energy, 'J')}`, 14, y)
+      y += 5
+      doc.text(`Energy (MT TNT): ${formatNumber(impactResults.energyMT)}`, 14, y)
+      y += 5
+      const devastation = adjustedResults?.adjustedDevastationRadius ?? impactResults.devastationRadius
+      doc.text(`Devastation radius: ${formatNumber(devastation, 'km')}`, 14, y)
+      y += 5
+      const crater = adjustedResults?.adjustedCraterDiameter ?? impactResults.craterDiameter
+      doc.text(`Crater diameter: ${formatNumber(crater, 'km')}`, 14, y)
+      y += 5
+      doc.text(`Population exposed: ${formatNumber(impactResults.population.exposed, 'people')}`, 14, y)
+      y += 5
+      doc.text(`Economic loss: ${formatNumber(impactResults.economic.directDamage, 'USD')}`, 14, y)
+    }
+
+    if (geology) {
+      y += 8
+      doc.setFontSize(13)
+      doc.text('Geology Context', 12, y)
+      doc.setFontSize(10)
+      y += 6
+      doc.text(`Profile: ${geology.profile.label}`, 14, y)
+      y += 5
+      if (geology.region) {
+        doc.text(`Region: ${geology.region.name}`, 14, y)
+        y += 5
+      }
+      doc.text(`Confidence: ${geology.confidence}`, 14, y)
+      y += 5
+      doc.text(`Terrain modifiers applied: ${geology.appliedTerrain ? 'Yes' : 'No'}`, 14, y)
+    }
+
+    if (orbitalData) {
+      y += 8
+      doc.setFontSize(13)
+      doc.text('Orbital Elements', 12, y)
+      doc.setFontSize(10)
+      y += 6
+      doc.text(`a: ${formatNumber(orbitalData.a, 'AU')}`, 14, y)
+      y += 5
+      doc.text(`e: ${formatNumber(orbitalData.e)}`, 14, y)
+      y += 5
+      doc.text(`i: ${formatNumber(orbitalData.i, 'rad')}`, 14, y)
+      y += 5
+      doc.text(`Ω: ${formatNumber(orbitalData.omega, 'rad')}`, 14, y)
+      y += 5
+      doc.text(`ω: ${formatNumber(orbitalData.w, 'rad')}`, 14, y)
+    }
+
+    doc.save('impactor-2025-scenario.pdf')
+    setStatus('PDF report generated.')
+    resetStatusLater()
+  }
+
+  const handleDownloadJson = () => {
+    if (!neo) {
+      setStatus('Select a NEO before exporting data.')
+      resetStatusLater()
+      return
+    }
+
+    const payload = {
+      generatedAt: new Date().toISOString(),
+      neo: {
+        id: neo.id,
+        name: neo.name,
+      },
+      location,
+      impactParams,
+      impactResults,
+      adjustedResults,
+      geology,
+      orbitalData,
+    }
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+    downloadBlob(blob, 'impactor-2025-scenario.json')
+    setStatus('JSON data downloaded.')
+    resetStatusLater()
+  }
+
+  const handleDownloadCsv = () => {
+    if (!neo) {
+      setStatus('Select a NEO before exporting data.')
+      resetStatusLater()
+      return
+    }
+
+    const devastation = impactResults
+      ? adjustedResults?.adjustedDevastationRadius ?? impactResults.devastationRadius
+      : null
+    const crater = impactResults
+      ? adjustedResults?.adjustedCraterDiameter ?? impactResults.craterDiameter
+      : null
+
+    const rows = [
+      ['Field', 'Value'],
+      ['NEO', neo.name],
+      ['Latitude', location[0].toString()],
+      ['Longitude', location[1].toString()],
+      ['Diameter (m)', impactParams.diameter.toString()],
+      ['Velocity (km/s)', impactParams.velocity.toString()],
+      ['Density (kg/m³)', impactParams.density.toString()],
+      ['Surface', impactParams.target],
+      ['Devastation radius (km)', devastation ? devastation.toString() : ''],
+      ['Crater diameter (km)', crater ? crater.toString() : ''],
+      ['Population exposed', impactResults ? impactResults.population.exposed.toString() : ''],
+      ['Population displaced', impactResults ? impactResults.population.displaced.toString() : ''],
+      ['Economic loss (USD)', impactResults ? impactResults.economic.directDamage.toString() : ''],
+    ]
+
+    const csv = rows.map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(',')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    downloadBlob(blob, 'impactor-2025-scenario.csv')
+    setStatus('CSV data downloaded.')
+    resetStatusLater()
+  }
+
+  const handleExportOrbitImage = async () => {
+    if (!orbitHandle) {
+      setStatus('Orbit visualization not ready yet.')
+      resetStatusLater()
+      return
+    }
+
+    const blob = await orbitHandle.exportImage()
+    if (!blob) {
+      setStatus('Unable to capture orbit visualization.')
+      resetStatusLater()
+      return
+    }
+
+    downloadBlob(blob, 'impactor-2025-orbit.png')
+    setStatus('Orbit visualization exported.')
+    resetStatusLater()
+  }
+
+  const handleExportMapImage = async () => {
+    if (!mapHandle) {
+      setStatus('Impact map not ready yet.')
+      resetStatusLater()
+      return
+    }
+
+    const blob = await mapHandle.exportImage()
+    if (!blob) {
+      setStatus('Unable to capture map visualization.')
+      resetStatusLater()
+      return
+    }
+
+    downloadBlob(blob, 'impactor-2025-impact-map.png')
+    setStatus('Impact map exported.')
+    resetStatusLater()
+  }
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4 text-sm">
+      <div>
+        <h3 className="text-base font-semibold">Export &amp; sharing</h3>
+        <p className="text-[11px] label">Capture the current scenario to share with colleagues or archive planning drills.</p>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={handleGeneratePdf}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Generate PDF report
+        </button>
+        <button
+          type="button"
+          onClick={handleCopyShareLink}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Copy shareable link
+        </button>
+        <button
+          type="button"
+          onClick={handleExportOrbitImage}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Export orbit visualization
+        </button>
+        <button
+          type="button"
+          onClick={handleExportMapImage}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Export impact map
+        </button>
+        <button
+          type="button"
+          onClick={handleDownloadJson}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Download data (JSON)
+        </button>
+        <button
+          type="button"
+          onClick={handleDownloadCsv}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left transition-colors hover:border-white/30 hover:bg-white/10"
+        >
+          Download data (CSV)
+        </button>
+      </div>
+      {status ? <div className="text-[11px] label">{status}</div> : null}
+      {shareUrl ? (
+        <div className="text-[10px] break-all rounded-lg border border-white/5 bg-black/40 p-2 font-mono text-white/70">
+          {shareUrl}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ImpactMap.tsx
+++ b/src/components/ImpactMap.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import L from 'leaflet'
 import type { ImpactResults } from '../types'
 import type { GeologyAdjustedResults } from '../utils/geology'
 import { useLanguage } from '../contexts/LanguageContext'
 import 'leaflet/dist/leaflet.css'
+import html2canvas from 'html2canvas'
 
 // Fix Leaflet marker icon issue with Vite
 import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
@@ -17,6 +18,10 @@ L.Icon.Default.mergeOptions({
   shadowUrl: markerShadow,
 })
 
+export interface ImpactMapHandle {
+  exportImage: () => Promise<Blob | null>
+}
+
 interface ImpactMapProps {
   location: [number, number]
   results: ImpactResults | null
@@ -24,148 +29,176 @@ interface ImpactMapProps {
   onLocationSelect: (lat: number, lng: number) => void
 }
 
-export default function ImpactMap({ location, results, adjustedResults, onLocationSelect }: ImpactMapProps) {
-  const { t } = useLanguage()
-  const mapRef = useRef<L.Map | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const impactMarkerRef = useRef<L.Marker | null>(null)
-  const devRingRef = useRef<L.Circle | null>(null)
-  const craterRingRef = useRef<L.Circle | null>(null)
-  const tileLayerRef = useRef<L.TileLayer | null>(null)
+const ImpactMap = forwardRef<ImpactMapHandle, ImpactMapProps>(
+  ({ location, results, adjustedResults, onLocationSelect }, ref) => {
+    const { t } = useLanguage()
+    const mapRef = useRef<L.Map | null>(null)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const impactMarkerRef = useRef<L.Marker | null>(null)
+    const devRingRef = useRef<L.Circle | null>(null)
+    const craterRingRef = useRef<L.Circle | null>(null)
+    const tileLayerRef = useRef<L.TileLayer | null>(null)
 
-  // Initialize map
-  useEffect(() => {
-    if (!containerRef.current || mapRef.current) return
+    // Initialize map
+    useEffect(() => {
+      if (!containerRef.current || mapRef.current) return
 
-    const map = L.map(containerRef.current, { worldCopyJump: true }).setView(location, 4)
-    mapRef.current = map
+      const map = L.map(containerRef.current, { worldCopyJump: true }).setView(location, 4)
+      mapRef.current = map
 
-    const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 15,
-      attribution: '&copy; OpenStreetMap contributors'
-    })
-    tileLayer.addTo(map)
-    tileLayerRef.current = tileLayer
+      const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 15,
+        attribution: '&copy; OpenStreetMap contributors'
+      })
+      tileLayer.addTo(map)
+      tileLayerRef.current = tileLayer
 
-    // Add click handler
-    const handleClick = (e: L.LeafletMouseEvent) => {
-      onLocationSelect(e.latlng.lat, e.latlng.lng)
-    }
-    map.on('click', handleClick)
-
-    // Add initial marker
-    const marker = L.marker(location, { title: 'Impact' }).addTo(map)
-    impactMarkerRef.current = marker
-
-    return () => {
-      // Remove click handler
-      map.off('click', handleClick)
-
-      // Remove all layers
-      if (tileLayerRef.current) {
-        tileLayerRef.current.remove()
-        tileLayerRef.current = null
+      // Add click handler
+      const handleClick = (e: L.LeafletMouseEvent) => {
+        onLocationSelect(e.latlng.lat, e.latlng.lng)
       }
+      map.on('click', handleClick)
 
+      // Add initial marker
+      const marker = L.marker(location, { title: 'Impact' }).addTo(map)
+      impactMarkerRef.current = marker
+
+      return () => {
+        // Remove click handler
+        map.off('click', handleClick)
+
+        // Remove all layers
+        if (tileLayerRef.current) {
+          tileLayerRef.current.remove()
+          tileLayerRef.current = null
+        }
+
+        if (impactMarkerRef.current) {
+          impactMarkerRef.current.remove()
+          impactMarkerRef.current = null
+        }
+
+        if (devRingRef.current) {
+          devRingRef.current.remove()
+          devRingRef.current = null
+        }
+
+        if (craterRingRef.current) {
+          craterRingRef.current.remove()
+          craterRingRef.current = null
+        }
+
+        // Remove map instance
+        map.remove()
+        mapRef.current = null
+      }
+    }, [])
+
+    // Update location
+    useEffect(() => {
+      if (!mapRef.current) return
+
+      // Update or create marker
       if (impactMarkerRef.current) {
         impactMarkerRef.current.remove()
-        impactMarkerRef.current = null
+      }
+      const marker = L.marker(location, { title: 'Impact' }).addTo(mapRef.current)
+      impactMarkerRef.current = marker
+
+      // Update rings
+      updateRings()
+    }, [location])
+
+    // Update rings when results change
+    useEffect(() => {
+      updateRings()
+    }, [results, adjustedResults])
+
+    const updateRings = () => {
+      if (!mapRef.current || !impactMarkerRef.current) return
+
+      const effectiveDevastation =
+        adjustedResults?.adjustedDevastationRadius ?? results?.devastationRadius
+      const effectiveCrater =
+        adjustedResults?.adjustedCraterDiameter ?? results?.craterDiameter
+
+      if (effectiveDevastation == null || effectiveCrater == null) {
+        if (devRingRef.current) {
+          devRingRef.current.remove()
+          devRingRef.current = null
+        }
+        if (craterRingRef.current) {
+          craterRingRef.current.remove()
+          craterRingRef.current = null
+        }
+        return
       }
 
+      const latLng = impactMarkerRef.current.getLatLng()
+
+      // Remove old rings
       if (devRingRef.current) {
         devRingRef.current.remove()
-        devRingRef.current = null
-      }
-
-      if (craterRingRef.current) {
-        craterRingRef.current.remove()
-        craterRingRef.current = null
-      }
-
-      // Remove map instance
-      map.remove()
-      mapRef.current = null
-    }
-  }, [])
-
-  // Update location
-  useEffect(() => {
-    if (!mapRef.current) return
-
-    // Update or create marker
-    if (impactMarkerRef.current) {
-      impactMarkerRef.current.remove()
-    }
-    const marker = L.marker(location, { title: 'Impact' }).addTo(mapRef.current)
-    impactMarkerRef.current = marker
-
-    // Update rings
-    updateRings()
-  }, [location])
-
-  // Update rings when results change
-  useEffect(() => {
-    updateRings()
-  }, [results, adjustedResults])
-
-  const updateRings = () => {
-    if (!mapRef.current || !impactMarkerRef.current) return
-
-    const effectiveDevastation =
-      adjustedResults?.adjustedDevastationRadius ?? results?.devastationRadius
-    const effectiveCrater =
-      adjustedResults?.adjustedCraterDiameter ?? results?.craterDiameter
-
-    if (effectiveDevastation == null || effectiveCrater == null) {
-      if (devRingRef.current) {
-        devRingRef.current.remove()
-        devRingRef.current = null
       }
       if (craterRingRef.current) {
         craterRingRef.current.remove()
-        craterRingRef.current = null
       }
-      return
+
+      // Add new rings
+      const devRadius = effectiveDevastation * 1000 // convert km to meters
+      const craterRadius = (effectiveCrater / 2) * 1000 // convert km to meters
+
+      const devRing = L.circle(latLng, {
+        radius: devRadius,
+        color: '#f59e0b',
+        fill: false,
+        weight: 2
+      }).addTo(mapRef.current)
+      devRingRef.current = devRing
+
+      const craterRing = L.circle(latLng, {
+        radius: craterRadius,
+        color: '#ef4444',
+        fill: false,
+        weight: 2
+      }).addTo(mapRef.current)
+      craterRingRef.current = craterRing
     }
 
-    const latLng = impactMarkerRef.current.getLatLng()
+    useImperativeHandle(
+      ref,
+      () => ({
+        async exportImage() {
+          if (!containerRef.current) {
+            return null
+          }
 
-    // Remove old rings
-    if (devRingRef.current) {
-      devRingRef.current.remove()
-    }
-    if (craterRingRef.current) {
-      craterRingRef.current.remove()
-    }
+          const canvas = await html2canvas(containerRef.current, {
+            backgroundColor: '#040713',
+            useCORS: true,
+            scale: 2,
+          })
 
-    // Add new rings
-    const devRadius = effectiveDevastation * 1000 // convert km to meters
-    const craterRadius = (effectiveCrater / 2) * 1000 // convert km to meters
+          return await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob((blob) => resolve(blob), 'image/png')
+          })
+        },
+      }),
+      []
+    )
 
-    const devRing = L.circle(latLng, {
-      radius: devRadius,
-      color: '#f59e0b',
-      fill: false,
-      weight: 2
-    }).addTo(mapRef.current)
-    devRingRef.current = devRing
-
-    const craterRing = L.circle(latLng, {
-      radius: craterRadius,
-      color: '#ef4444',
-      fill: false,
-      weight: 2
-    }).addTo(mapRef.current)
-    craterRingRef.current = craterRing
-  }
-
-  return (
-    <div className="space-y-3">
-      <h2 className="text-base sm:text-lg font-semibold pt-2">{t('impactMap.title')}</h2>
-      <div ref={containerRef} className="w-full h-64 sm:h-80 rounded-xl border border-white/10" />
-      <div className="text-[10px] sm:text-xs label">
-        {t('impactMap.description')}
+    return (
+      <div className="space-y-3">
+        <h2 className="text-base sm:text-lg font-semibold pt-2">{t('impactMap.title')}</h2>
+        <div ref={containerRef} className="w-full h-64 sm:h-80 rounded-xl border border-white/10" />
+        <div className="text-[10px] sm:text-xs label">
+          {t('impactMap.description')}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+);
+
+ImpactMap.displayName = 'ImpactMap'
+
+export default ImpactMap

--- a/src/components/NEOBrowser.tsx
+++ b/src/components/NEOBrowser.tsx
@@ -8,10 +8,12 @@ const API_KEY = 'QVQTFgjfy9QfI1tI237pylpTfp4K53a4lrtYquHL'
 interface NEOBrowserProps {
   onNEOSelect: (neo: NEO, orbital: OrbitalData) => void
   onParamsUpdate: (params: Partial<ImpactParams>) => void
+  initialNEOId?: string | null
 }
 
-export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserProps) {
+export default function NEOBrowser({ onNEOSelect, onParamsUpdate, initialNEOId }: NEOBrowserProps) {
   const isMounted = useRef(true)
+  const hasInitialised = useRef(false)
   const [neos, setNeos] = useState<NEO[]>([])
   const [loading, setLoading] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -117,9 +119,17 @@ export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserPr
   useEffect(() => {
     isMounted.current = true
     browseNEOs().then((dataset) => {
-      if (!isMounted.current) {
+      if (!isMounted.current || hasInitialised.current) {
         return
       }
+
+      hasInitialised.current = true
+
+      if (initialNEOId) {
+        selectNEO(initialNEOId)
+        return
+      }
+
       const scenarioNeo = dataset.find((item) => item.id === IMPACTOR_2025.id)
       if (scenarioNeo) {
         handleSelection(scenarioNeo)
@@ -128,7 +138,7 @@ export default function NEOBrowser({ onNEOSelect, onParamsUpdate }: NEOBrowserPr
     return () => {
       isMounted.current = false
     }
-  }, [])
+  }, [initialNEOId])
 
   const filteredNEOs = neos.filter(neo =>
     neo.name.toLowerCase().includes(searchQuery.toLowerCase())

--- a/src/components/OrbitVisualization.tsx
+++ b/src/components/OrbitVisualization.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import type { OrbitalData } from '../types'
@@ -13,309 +13,336 @@ import {
 import { useLanguage } from '../contexts/LanguageContext'
 import OrbitalMechanicsExplainers from './OrbitalMechanicsExplainers'
 
+export interface OrbitVisualizationHandle {
+  exportImage: () => Promise<Blob | null>
+}
+
 interface OrbitVisualizationProps {
   orbitalData: OrbitalData | null
 }
 
-export default function OrbitVisualization({ orbitalData }: OrbitVisualizationProps) {
-  const { t } = useLanguage()
-  const containerRef = useRef<HTMLDivElement>(null)
-  const sceneRef = useRef<THREE.Scene | null>(null)
-  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null)
-  const rendererRef = useRef<THREE.WebGLRenderer | null>(null)
-  const controlsRef = useRef<OrbitControls | null>(null)
-  const orbitLineRef = useRef<THREE.Line | null>(null)
-  const asteroidMarkerRef = useRef<THREE.Mesh | null>(null)
-  const earthMarkerRef = useRef<THREE.Mesh | null>(null)
-  const currentOrbitRef = useRef<OrbitalData | null>(null)
-  const asteroidMRef = useRef(0)
-  const earthMRef = useRef(0)
-  const lastTimeRef = useRef(performance.now())
-  const timeScaleRef = useRef(2000000)
-  const astroSpeedRef = useRef(1)
-  const astroDirRef = useRef(1)
-  const earthSpeedRef = useRef(1)
-  const earthDirRef = useRef(1)
+const OrbitVisualization = forwardRef<OrbitVisualizationHandle, OrbitVisualizationProps>(
+  ({ orbitalData }, ref) => {
+    const { t } = useLanguage()
+    const containerRef = useRef<HTMLDivElement>(null)
+    const sceneRef = useRef<THREE.Scene | null>(null)
+    const cameraRef = useRef<THREE.PerspectiveCamera | null>(null)
+    const rendererRef = useRef<THREE.WebGLRenderer | null>(null)
+    const controlsRef = useRef<OrbitControls | null>(null)
+    const orbitLineRef = useRef<THREE.Line | null>(null)
+    const asteroidMarkerRef = useRef<THREE.Mesh | null>(null)
+    const earthMarkerRef = useRef<THREE.Mesh | null>(null)
+    const currentOrbitRef = useRef<OrbitalData | null>(null)
+    const asteroidMRef = useRef(0)
+    const earthMRef = useRef(0)
+    const lastTimeRef = useRef(performance.now())
+    const timeScaleRef = useRef(2000000)
+    const astroSpeedRef = useRef(1)
+    const astroDirRef = useRef(1)
+    const earthSpeedRef = useRef(1)
+    const earthDirRef = useRef(1)
 
-  const [timeScale, setTimeScale] = useState(2000000)
-  const [astroSpeed, setAstroSpeed] = useState(1)
-  const [astroDir, setAstroDir] = useState(1)
-  const [earthSpeed, setEarthSpeed] = useState(1)
-  const [earthDir, setEarthDir] = useState(1)
+    const [timeScale, setTimeScale] = useState(2000000)
+    const [astroSpeed, setAstroSpeed] = useState(1)
+    const [astroDir, setAstroDir] = useState(1)
+    const [earthSpeed, setEarthSpeed] = useState(1)
+    const [earthDir, setEarthDir] = useState(1)
 
-  // Initialize scene
-  useEffect(() => {
-    if (!containerRef.current) return
+    // Initialize scene
+    useEffect(() => {
+      if (!containerRef.current) return
 
-    const scene = new THREE.Scene()
-    scene.background = new THREE.Color(0x0b1020)
-    sceneRef.current = scene
+      const scene = new THREE.Scene()
+      scene.background = new THREE.Color(0x0b1020)
+      sceneRef.current = scene
 
-    const camera = new THREE.PerspectiveCamera(
-      60,
-      containerRef.current.clientWidth / containerRef.current.clientHeight,
-      0.01,
-      1000
-    )
-    camera.position.set(3, 2, 3)
-    cameraRef.current = camera
-
-    const renderer = new THREE.WebGLRenderer({ antialias: true })
-    renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight)
-    containerRef.current.appendChild(renderer.domElement)
-    rendererRef.current = renderer
-
-    const controls = new OrbitControls(camera, renderer.domElement)
-    controlsRef.current = controls
-
-    // Sun
-    const sunGeometry = new THREE.SphereGeometry(0.05, 32, 16)
-    const sunMaterial = new THREE.MeshBasicMaterial({ color: 0xffcc66 })
-    const sun = new THREE.Mesh(sunGeometry, sunMaterial)
-    scene.add(sun)
-
-    // Earth's orbit (unit circle)
-    const earthGeom = new THREE.BufferGeometry()
-    const earthPts: number[] = []
-    for (let t = 0; t <= 360; t++) {
-      const r = (t * Math.PI) / 180
-      earthPts.push(Math.cos(r), 0, Math.sin(r))
-    }
-    earthGeom.setAttribute('position', new THREE.Float32BufferAttribute(earthPts, 3))
-    const earthOrbitMaterial = new THREE.LineBasicMaterial({ transparent: true, opacity: 0.5 })
-    const earthOrbit = new THREE.Line(earthGeom, earthOrbitMaterial)
-    scene.add(earthOrbit)
-
-    // Earth marker
-    const earthGeometry = new THREE.SphereGeometry(0.03, 24, 12)
-    const earthMaterial = new THREE.MeshBasicMaterial({ color: 0x3b82f6 })
-    const earthMarker = new THREE.Mesh(earthGeometry, earthMaterial)
-    scene.add(earthMarker)
-    earthMarkerRef.current = earthMarker
-
-    // Asteroid marker
-    const asteroidGeometry = new THREE.SphereGeometry(0.025, 18, 9)
-    const asteroidMaterial = new THREE.MeshBasicMaterial({ color: 0x64d2ff })
-    const asteroidMarker = new THREE.Mesh(asteroidGeometry, asteroidMaterial)
-    scene.add(asteroidMarker)
-    asteroidMarkerRef.current = asteroidMarker
-
-    // Set default orbit
-    updateOrbit(getDefaultOrbit())
-
-    // Animation loop with cleanup flag
-    let animationId: number
-    let isRunning = true
-
-    const animate = () => {
-      if (!isRunning) return
-
-      animationId = requestAnimationFrame(animate)
-
-      const now = performance.now()
-      const dt = Math.min(0.1, (now - lastTimeRef.current) / 1000)
-      lastTimeRef.current = now
-
-      // Update Earth position
-      earthMRef.current +=
-        earthDirRef.current *
-        earthSpeedRef.current *
-        EARTH_MEAN_MOTION *
-        dt *
-        timeScaleRef.current
-      earthMarker.position.set(
-        Math.cos(earthMRef.current),
-        0,
-        Math.sin(earthMRef.current)
+      const camera = new THREE.PerspectiveCamera(
+        60,
+        containerRef.current.clientWidth / containerRef.current.clientHeight,
+        0.01,
+        1000
       )
+      camera.position.set(3, 2, 3)
+      cameraRef.current = camera
 
-      // Update asteroid position
-      if (currentOrbitRef.current && asteroidMarkerRef.current) {
-        const n = getMeanMotion(currentOrbitRef.current.a)
-        asteroidMRef.current +=
-          astroDirRef.current * astroSpeedRef.current * n * dt * timeScaleRef.current
-        const nu = trueAnomalyFromMean(asteroidMRef.current, currentOrbitRef.current.e)
-        const pos = positionOnOrbit(nu, currentOrbitRef.current)
-        asteroidMarkerRef.current.position.copy(pos)
+      const renderer = new THREE.WebGLRenderer({ antialias: true })
+      renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight)
+      containerRef.current.appendChild(renderer.domElement)
+      rendererRef.current = renderer
+
+      const controls = new OrbitControls(camera, renderer.domElement)
+      controlsRef.current = controls
+
+      // Sun
+      const sunGeometry = new THREE.SphereGeometry(0.05, 32, 16)
+      const sunMaterial = new THREE.MeshBasicMaterial({ color: 0xffcc66 })
+      const sun = new THREE.Mesh(sunGeometry, sunMaterial)
+      scene.add(sun)
+
+      // Earth's orbit (unit circle)
+      const earthGeom = new THREE.BufferGeometry()
+      const earthPts: number[] = []
+      for (let t = 0; t <= 360; t++) {
+        const r = (t * Math.PI) / 180
+        earthPts.push(Math.cos(r), 0, Math.sin(r))
       }
+      earthGeom.setAttribute('position', new THREE.Float32BufferAttribute(earthPts, 3))
+      const earthOrbitMaterial = new THREE.LineBasicMaterial({ transparent: true, opacity: 0.5 })
+      const earthOrbit = new THREE.Line(earthGeom, earthOrbitMaterial)
+      scene.add(earthOrbit)
 
-      controls.update()
-      renderer.render(scene, camera)
-    }
-    animate()
+      // Earth marker
+      const earthGeometry = new THREE.SphereGeometry(0.03, 24, 12)
+      const earthMaterial = new THREE.MeshBasicMaterial({ color: 0x3b82f6 })
+      const earthMarker = new THREE.Mesh(earthGeometry, earthMaterial)
+      scene.add(earthMarker)
+      earthMarkerRef.current = earthMarker
 
-    // Resize handler
-    const handleResize = () => {
-      if (!containerRef.current || !cameraRef.current || !rendererRef.current) return
-      const width = containerRef.current.clientWidth
-      const height = containerRef.current.clientHeight
-      rendererRef.current.setSize(width, height)
-      cameraRef.current.aspect = width / height
-      cameraRef.current.updateProjectionMatrix()
-    }
-    window.addEventListener('resize', handleResize)
+      // Asteroid marker
+      const asteroidGeometry = new THREE.SphereGeometry(0.025, 18, 9)
+      const asteroidMaterial = new THREE.MeshBasicMaterial({ color: 0x64d2ff })
+      const asteroidMarker = new THREE.Mesh(asteroidGeometry, asteroidMaterial)
+      scene.add(asteroidMarker)
+      asteroidMarkerRef.current = asteroidMarker
 
-    return () => {
-      // Stop animation loop
-      isRunning = false
-      if (animationId) {
-        cancelAnimationFrame(animationId)
+      // Set default orbit
+      updateOrbit(getDefaultOrbit())
+
+      // Animation loop with cleanup flag
+      let animationId: number
+      let isRunning = true
+
+      const animate = () => {
+        if (!isRunning) return
+
+        animationId = requestAnimationFrame(animate)
+
+        const now = performance.now()
+        const dt = Math.min(0.1, (now - lastTimeRef.current) / 1000)
+        lastTimeRef.current = now
+
+        // Update Earth position
+        earthMRef.current +=
+          earthDirRef.current *
+          earthSpeedRef.current *
+          EARTH_MEAN_MOTION *
+          dt *
+          timeScaleRef.current
+        earthMarker.position.set(
+          Math.cos(earthMRef.current),
+          0,
+          Math.sin(earthMRef.current)
+        )
+
+        // Update asteroid position
+        if (currentOrbitRef.current && asteroidMarkerRef.current) {
+          const n = getMeanMotion(currentOrbitRef.current.a)
+          asteroidMRef.current +=
+            astroDirRef.current * astroSpeedRef.current * n * dt * timeScaleRef.current
+          const nu = trueAnomalyFromMean(asteroidMRef.current, currentOrbitRef.current.e)
+          const pos = positionOnOrbit(nu, currentOrbitRef.current)
+          asteroidMarkerRef.current.position.copy(pos)
+        }
+
+        controls.update()
+        renderer.render(scene, camera)
       }
+      animate()
 
-      // Dispose controls
-      controls.dispose()
+      // Resize handler
+      const handleResize = () => {
+        if (!containerRef.current || !cameraRef.current || !rendererRef.current) return
+        const width = containerRef.current.clientWidth
+        const height = containerRef.current.clientHeight
+        rendererRef.current.setSize(width, height)
+        cameraRef.current.aspect = width / height
+        cameraRef.current.updateProjectionMatrix()
+      }
+      window.addEventListener('resize', handleResize)
 
-      // Dispose geometries and materials
-      sunGeometry.dispose()
-      sunMaterial.dispose()
-      earthGeom.dispose()
-      earthOrbitMaterial.dispose()
-      earthGeometry.dispose()
-      earthMaterial.dispose()
-      asteroidGeometry.dispose()
-      asteroidMaterial.dispose()
+      return () => {
+        // Stop animation loop
+        isRunning = false
+        if (animationId) {
+          cancelAnimationFrame(animationId)
+        }
 
-      // Dispose orbit line if exists
+        // Dispose controls
+        controls.dispose()
+
+        // Dispose geometries and materials
+        sunGeometry.dispose()
+        sunMaterial.dispose()
+        earthGeom.dispose()
+        earthOrbitMaterial.dispose()
+        earthGeometry.dispose()
+        earthMaterial.dispose()
+        asteroidGeometry.dispose()
+        asteroidMaterial.dispose()
+
+        // Dispose orbit line if exists
+        if (orbitLineRef.current) {
+          orbitLineRef.current.geometry.dispose()
+          ;(orbitLineRef.current.material as THREE.Material).dispose()
+        }
+
+        // Dispose renderer
+        renderer.dispose()
+
+        // Remove resize listener
+        window.removeEventListener('resize', handleResize)
+
+        // Remove DOM element
+        if (containerRef.current?.contains(renderer.domElement)) {
+          containerRef.current.removeChild(renderer.domElement)
+        }
+
+        // Clear refs
+        sceneRef.current = null
+        cameraRef.current = null
+        rendererRef.current = null
+        controlsRef.current = null
+      }
+    }, [])
+
+    // Update animation parameters
+    useEffect(() => {
+      timeScaleRef.current = timeScale
+    }, [timeScale])
+
+    useEffect(() => {
+      astroSpeedRef.current = astroSpeed
+    }, [astroSpeed])
+
+    useEffect(() => {
+      astroDirRef.current = astroDir
+    }, [astroDir])
+
+    useEffect(() => {
+      earthSpeedRef.current = earthSpeed
+    }, [earthSpeed])
+
+    useEffect(() => {
+      earthDirRef.current = earthDir
+    }, [earthDir])
+
+    // Update orbit when orbitalData changes
+    useEffect(() => {
+      if (orbitalData) {
+        updateOrbit(orbitalData)
+      }
+    }, [orbitalData])
+
+    const updateOrbit = (orbit: OrbitalData) => {
+      if (!sceneRef.current) return
+
+      // Remove old orbit line
       if (orbitLineRef.current) {
+        sceneRef.current.remove(orbitLineRef.current)
         orbitLineRef.current.geometry.dispose()
         ;(orbitLineRef.current.material as THREE.Material).dispose()
       }
 
-      // Dispose renderer
-      renderer.dispose()
+      // Generate new orbit
+      const points = generateOrbitPoints(orbit)
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute('position', new THREE.BufferAttribute(points, 3))
+      const orbitLine = new THREE.Line(
+        geometry,
+        new THREE.LineBasicMaterial({ color: 0x64d2ff })
+      )
+      sceneRef.current.add(orbitLine)
+      orbitLineRef.current = orbitLine
 
-      // Remove resize listener
-      window.removeEventListener('resize', handleResize)
-
-      // Remove DOM element
-      if (containerRef.current?.contains(renderer.domElement)) {
-        containerRef.current.removeChild(renderer.domElement)
-      }
-
-      // Clear refs
-      sceneRef.current = null
-      cameraRef.current = null
-      rendererRef.current = null
-      controlsRef.current = null
-    }
-  }, [])
-
-  // Update animation parameters
-  useEffect(() => {
-    timeScaleRef.current = timeScale
-  }, [timeScale])
-
-  useEffect(() => {
-    astroSpeedRef.current = astroSpeed
-  }, [astroSpeed])
-
-  useEffect(() => {
-    astroDirRef.current = astroDir
-  }, [astroDir])
-
-  useEffect(() => {
-    earthSpeedRef.current = earthSpeed
-  }, [earthSpeed])
-
-  useEffect(() => {
-    earthDirRef.current = earthDir
-  }, [earthDir])
-
-  // Update orbit when orbitalData changes
-  useEffect(() => {
-    if (orbitalData) {
-      updateOrbit(orbitalData)
-    }
-  }, [orbitalData])
-
-  const updateOrbit = (orbit: OrbitalData) => {
-    if (!sceneRef.current) return
-
-    // Remove old orbit line
-    if (orbitLineRef.current) {
-      sceneRef.current.remove(orbitLineRef.current)
-      orbitLineRef.current.geometry.dispose()
-      ;(orbitLineRef.current.material as THREE.Material).dispose()
+      currentOrbitRef.current = orbit
+      asteroidMRef.current = 0 // reset position
     }
 
-    // Generate new orbit
-    const points = generateOrbitPoints(orbit)
-    const geometry = new THREE.BufferGeometry()
-    geometry.setAttribute('position', new THREE.BufferAttribute(points, 3))
-    const orbitLine = new THREE.Line(
-      geometry,
-      new THREE.LineBasicMaterial({ color: 0x64d2ff })
+    useImperativeHandle(
+      ref,
+      () => ({
+        async exportImage() {
+          const canvas = rendererRef.current?.domElement
+          if (!canvas) {
+            return null
+          }
+
+          return await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob((blob) => resolve(blob), 'image/png')
+          })
+        },
+      }),
+      []
     )
-    sceneRef.current.add(orbitLine)
-    orbitLineRef.current = orbitLine
 
-    currentOrbitRef.current = orbit
-    asteroidMRef.current = 0 // reset position
-  }
-
-  return (
-    <div className="space-y-3">
-      <h2 className="text-base sm:text-lg font-semibold">{t('orbitViz.title')}</h2>
-      <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 sm:gap-3 items-start sm:items-center text-xs sm:text-sm mb-2">
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <span className="label whitespace-nowrap">{t('orbitViz.timeScale')}</span>
-          <input
-            type="range"
-            min="1000"
-            max="50000000"
-            step="1000"
-            value={timeScale}
-            onChange={(e) => setTimeScale(Number(e.target.value))}
-            className="flex-1 sm:w-32 lg:w-56"
-          />
-          <span className="label text-[10px] sm:text-xs whitespace-nowrap">{timeScale.toLocaleString()}×</span>
+    return (
+      <div className="space-y-3">
+        <h2 className="text-base sm:text-lg font-semibold">{t('orbitViz.title')}</h2>
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 sm:gap-3 items-start sm:items-center text-xs sm:text-sm mb-2">
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <span className="label whitespace-nowrap">{t('orbitViz.timeScale')}</span>
+            <input
+              type="range"
+              min="1000"
+              max="50000000"
+              step="1000"
+              value={timeScale}
+              onChange={(e) => setTimeScale(Number(e.target.value))}
+              className="flex-1 sm:w-32 lg:w-56"
+            />
+            <span className="label text-[10px] sm:text-xs whitespace-nowrap">{timeScale.toLocaleString()}×</span>
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <span className="label whitespace-nowrap min-w-[60px]">{t('orbitViz.asteroid')}</span>
+            <input
+              type="range"
+              min="0"
+              max="5"
+              step="0.1"
+              value={astroSpeed}
+              onChange={(e) => setAstroSpeed(Number(e.target.value))}
+              className="flex-1 sm:w-24 lg:w-32"
+            />
+            <select
+              value={astroDir}
+              onChange={(e) => setAstroDir(Number(e.target.value))}
+              className="bg-black/30 border border-white/10 rounded p-1 text-[10px] sm:text-xs"
+            >
+              <option value="1">{t('orbitViz.forward')}</option>
+              <option value="-1">{t('orbitViz.reverse')}</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <span className="label whitespace-nowrap min-w-[60px]">{t('orbitViz.earth')}</span>
+            <input
+              type="range"
+              min="0"
+              max="5"
+              step="0.1"
+              value={earthSpeed}
+              onChange={(e) => setEarthSpeed(Number(e.target.value))}
+              className="flex-1 sm:w-24 lg:w-32"
+            />
+            <select
+              value={earthDir}
+              onChange={(e) => setEarthDir(Number(e.target.value))}
+              className="bg-black/30 border border-white/10 rounded p-1 text-[10px] sm:text-xs"
+            >
+              <option value="1">{t('orbitViz.forward')}</option>
+              <option value="-1">{t('orbitViz.reverse')}</option>
+            </select>
+          </div>
         </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <span className="label whitespace-nowrap min-w-[60px]">{t('orbitViz.asteroid')}</span>
-          <input
-            type="range"
-            min="0"
-            max="5"
-            step="0.1"
-            value={astroSpeed}
-            onChange={(e) => setAstroSpeed(Number(e.target.value))}
-            className="flex-1 sm:w-24 lg:w-32"
-          />
-          <select
-            value={astroDir}
-            onChange={(e) => setAstroDir(Number(e.target.value))}
-            className="bg-black/30 border border-white/10 rounded p-1 text-[10px] sm:text-xs"
-          >
-            <option value="1">{t('orbitViz.forward')}</option>
-            <option value="-1">{t('orbitViz.reverse')}</option>
-          </select>
-        </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <span className="label whitespace-nowrap min-w-[60px]">{t('orbitViz.earth')}</span>
-          <input
-            type="range"
-            min="0"
-            max="5"
-            step="0.1"
-            value={earthSpeed}
-            onChange={(e) => setEarthSpeed(Number(e.target.value))}
-            className="flex-1 sm:w-24 lg:w-32"
-          />
-          <select
-            value={earthDir}
-            onChange={(e) => setEarthDir(Number(e.target.value))}
-            className="bg-black/30 border border-white/10 rounded p-1 text-[10px] sm:text-xs"
-          >
-            <option value="1">{t('orbitViz.forward')}</option>
-            <option value="-1">{t('orbitViz.reverse')}</option>
-          </select>
-        </div>
+        <div
+          ref={containerRef}
+          className="w-full h-64 md:h-80 lg:h-[28rem] rounded-xl border border-white/10"
+        />
+        <OrbitalMechanicsExplainers orbitalData={orbitalData} />
       </div>
-      <div
-        ref={containerRef}
-        className="w-full h-64 md:h-80 lg:h-[28rem] rounded-xl border border-white/10"
-      />
-      <OrbitalMechanicsExplainers orbitalData={orbitalData} />
-    </div>
-  )
-}
+    )
+  }
+);
+
+OrbitVisualization.displayName = 'OrbitVisualization'
+
+export default OrbitVisualization

--- a/src/utils/sharing.ts
+++ b/src/utils/sharing.ts
@@ -1,0 +1,79 @@
+import type { ImpactParams, SurfaceType } from '../types'
+
+export interface ShareState {
+  neoId?: string | null
+  params: ImpactParams
+  location: [number, number]
+}
+
+const surfaceTypes: SurfaceType[] = ['continental', 'oceanic', 'sedimentary']
+
+const isValidSurfaceType = (value: string): value is SurfaceType => {
+  return surfaceTypes.includes(value as SurfaceType)
+}
+
+export const encodeShareState = (baseUrl: string, state: ShareState): string => {
+  const params = new URLSearchParams()
+
+  if (state.neoId) {
+    params.set('neo', state.neoId)
+  }
+
+  params.set('d', state.params.diameter.toFixed(2))
+  params.set('v', state.params.velocity.toFixed(2))
+  params.set('rho', state.params.density.toFixed(2))
+  params.set('t', state.params.target)
+  params.set('lat', state.location[0].toFixed(4))
+  params.set('lng', state.location[1].toFixed(4))
+
+  const query = params.toString()
+  return query ? `${baseUrl}?${query}` : baseUrl
+}
+
+export const parseShareState = (search: string): ShareState | null => {
+  if (!search || search.length <= 1) {
+    return null
+  }
+
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+
+  const diameter = Number(params.get('d'))
+  const velocity = Number(params.get('v'))
+  const density = Number(params.get('rho'))
+  const target = params.get('t') ?? ''
+  const lat = Number(params.get('lat'))
+  const lng = Number(params.get('lng'))
+
+  if (
+    !Number.isFinite(diameter) ||
+    !Number.isFinite(velocity) ||
+    !Number.isFinite(density) ||
+    !Number.isFinite(lat) ||
+    !Number.isFinite(lng) ||
+    !isValidSurfaceType(target)
+  ) {
+    return null
+  }
+
+  const neoId = params.get('neo')
+
+  return {
+    neoId,
+    params: {
+      diameter,
+      velocity,
+      density,
+      target,
+    },
+    location: [lat, lng],
+  }
+}
+
+export const currentShareUrl = (state: ShareState): string | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const baseUrl = `${window.location.origin}${window.location.pathname}`
+  return encodeShareState(baseUrl, state)
+}


### PR DESCRIPTION
## Summary
- add an Export & sharing panel with PDF reporting, share link copying, visualization image capture, and CSV/JSON downloads
- expose capture handles from the orbit and map visualizations to support exporting imagery
- persist scenario state in URLs so shared links restore parameters and locations on load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1943a99e48331b99e3bf3d4d36f06