### PR TITLE
Refine UI layout for improved navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,55 +190,76 @@ function App() {
         onPreparednessClick={() => setPreparednessOpen(true)}
         onTutorialClick={() => setTutorialOpen(true)}
       />
-      <main className="max-w-7xl mx-auto p-4 grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1">
-        <section className="panel rounded-2xl p-4 space-y-4">
-          <NEOBrowser
-            onNEOSelect={handleNEOSelect}
-            onParamsUpdate={handleParamsUpdate}
-            initialNEOId={initialShare?.neoId ?? null}
-          />
-          <ImpactScenarioLibrary
-            scenarios={IMPACT_SCENARIOS}
-            onSelectScenario={handleScenarioLoad}
-          />
-          <NEOScenarioSummary
-            neo={selectedNEO}
-            impactResults={impactResults}
-            adjustedResults={adjustedImpactResults}
-            geology={geologyAssessment}
-            location={impactLocation}
-          />
-          <ImpactParameters
-            params={impactParams}
-            onParamsChange={(next) => setImpactParams(normalizeImpactParams(next))}
-            onCalculate={handleImpactCalculation}
-          />
-          <GeologyInsights assessment={geologyAssessment} adjustedResults={adjustedImpactResults} />
-          <ExportSharePanel
-            neo={selectedNEO}
-            impactParams={impactParams}
-            impactResults={impactResults}
-            adjustedResults={adjustedImpactResults}
-            geology={geologyAssessment}
-            location={impactLocation}
-            orbitalData={orbitalData}
-            orbitHandle={orbitRef.current}
-            mapHandle={mapRef.current}
-          />
-        </section>
-
-        <section className="panel rounded-2xl p-4 space-y-3 lg:col-span-2">
-          <OrbitVisualization ref={orbitRef} orbitalData={orbitalData} />
-          <ImpactMap
-            ref={mapRef}
-            location={impactLocation}
-            results={impactResults}
-            adjustedResults={adjustedImpactResults}
-            onLocationSelect={handleLocationSelect}
-          />
-        </section>
-
-        <MitigationStrategies neo={selectedNEO} className="lg:col-span-3" />
+      <main className="flex-1 w-full">
+        <div className="mx-auto flex w-full max-w-[1500px] flex-1 flex-col gap-6 px-4 py-6 sm:px-6 lg:px-10">
+          <div className="flex flex-col gap-6 xl:grid xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)] 2xl:grid-cols-[minmax(0,400px)_minmax(0,1.3fr)] xl:items-start">
+            <aside className="flex flex-col gap-6 xl:sticky xl:top-28 xl:max-h-[calc(100vh-8rem)] xl:overflow-y-auto xl:pr-3">
+              <section className="panel rounded-2xl p-5">
+                <NEOBrowser
+                  onNEOSelect={handleNEOSelect}
+                  onParamsUpdate={handleParamsUpdate}
+                  initialNEOId={initialShare?.neoId ?? null}
+                />
+              </section>
+              <section className="panel rounded-2xl p-5">
+                <ImpactScenarioLibrary
+                  scenarios={IMPACT_SCENARIOS}
+                  onSelectScenario={handleScenarioLoad}
+                />
+              </section>
+              <section className="panel rounded-2xl p-5">
+                <NEOScenarioSummary
+                  neo={selectedNEO}
+                  impactResults={impactResults}
+                  adjustedResults={adjustedImpactResults}
+                  geology={geologyAssessment}
+                  location={impactLocation}
+                />
+              </section>
+              <section className="panel rounded-2xl p-5">
+                <ImpactParameters
+                  params={impactParams}
+                  onParamsChange={(next) => setImpactParams(normalizeImpactParams(next))}
+                  onCalculate={handleImpactCalculation}
+                />
+              </section>
+              <section className="panel rounded-2xl p-5">
+                <GeologyInsights
+                  assessment={geologyAssessment}
+                  adjustedResults={adjustedImpactResults}
+                />
+              </section>
+              <section className="panel rounded-2xl p-5">
+                <ExportSharePanel
+                  neo={selectedNEO}
+                  impactParams={impactParams}
+                  impactResults={impactResults}
+                  adjustedResults={adjustedImpactResults}
+                  geology={geologyAssessment}
+                  location={impactLocation}
+                  orbitalData={orbitalData}
+                  orbitHandle={orbitRef.current}
+                  mapHandle={mapRef.current}
+                />
+              </section>
+            </aside>
+            <section className="flex flex-col gap-6 min-w-0">
+              <div className="panel rounded-2xl p-5">
+                <OrbitVisualization ref={orbitRef} orbitalData={orbitalData} />
+              </div>
+              <div className="panel rounded-2xl p-5">
+                <ImpactMap
+                  ref={mapRef}
+                  location={impactLocation}
+                  results={impactResults}
+                  adjustedResults={adjustedImpactResults}
+                  onLocationSelect={handleLocationSelect}
+                />
+              </div>
+            </section>
+          </div>
+          <MitigationStrategies neo={selectedNEO} className="xl:p-6" />
+        </div>
       </main>
       <Footer />
       <PreparednessModal open={isPreparednessOpen} onClose={() => setPreparednessOpen(false)} />

--- a/src/components/ExportSharePanel.tsx
+++ b/src/components/ExportSharePanel.tsx
@@ -278,7 +278,7 @@ export default function ExportSharePanel({
   }
 
   return (
-    <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4 text-sm">
+    <div className="space-y-4 text-sm">
       <div>
         <h3 className="text-base font-semibold">Export &amp; sharing</h3>
         <p className="text-[11px] label">Capture the current scenario to share with colleagues or archive planning drills.</p>

--- a/src/components/GeologyInsights.tsx
+++ b/src/components/GeologyInsights.tsx
@@ -30,7 +30,7 @@ const hazardEntries = (modifiers: GeologyAdjustedResults['hazardAdjustments']) =
 
 const GeologyInsights = ({ assessment, adjustedResults }: GeologyInsightsProps) => {
   return (
-    <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-sm">
+    <div className="space-y-4 text-sm">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-base font-semibold">Enhanced USGS geology</h3>
         {assessment ? (

--- a/src/index.css
+++ b/src/index.css
@@ -34,7 +34,10 @@
 }
 
 body {
-  background: var(--bg-primary);
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(65, 105, 225, 0.18), transparent),
+    linear-gradient(180deg, rgba(7, 11, 24, 0.85), rgba(7, 11, 24, 0.95)),
+    var(--bg-primary);
   color: var(--text-primary);
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -47,6 +50,9 @@ body {
 
 .panel {
   background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 25px 60px -35px rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
   transition: background-color 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- restructure the main dashboard into a responsive sticky sidebar and spacious visualization column to improve navigation
- refresh the global styling with a layered background and elevated panel treatment for better depth
- align geology and export panels with the new layout so they inherit the shared panel styling

## Testing
- npm run lint *(fails: ESLint configuration file is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e197fb8f008331a65803b2e14144f9