### PR TITLE
Add impact countdown and real-time controls to orbit visualization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,7 +245,11 @@ function App() {
             </aside>
             <section className="flex flex-col gap-6 min-w-0">
               <div className="panel rounded-2xl p-5">
-                <OrbitVisualization ref={orbitRef} orbitalData={orbitalData} />
+                <OrbitVisualization
+                  ref={orbitRef}
+                  orbitalData={orbitalData}
+                  impactDate={selectedNEO?.impact_scenario?.impact_date ?? null}
+                />
               </div>
               <div className="panel rounded-2xl p-5">
                 <ImpactMap

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -134,7 +134,15 @@ const translations: Record<Language, any> = {
       earth: 'Earth',
       forward: '⟲ forward',
       reverse: '⟳ reverse',
-      controls: 'Drag to rotate • Scroll to zoom'
+      controls: 'Drag to rotate • Scroll to zoom',
+      timeRemaining: 'Time until impact:',
+      timeRemainingUnknown: 'Impact time unavailable',
+      impactNow: 'Impact occurring now',
+      impactPaused: 'Impact detected — simulation paused.',
+      resume: 'Resume animation',
+      realTime: 'View in real time',
+      exitRealTime: 'Exit real time',
+      realTimeActive: 'Real-time mode'
     },
     impactMap: {
       title: 'Impact Map',
@@ -233,7 +241,15 @@ const translations: Record<Language, any> = {
       earth: 'Tierra',
       forward: '⟲ adelante',
       reverse: '⟳ reversa',
-      controls: 'Arrastra para rotar • Desplaza para zoom'
+      controls: 'Arrastra para rotar • Desplaza para zoom',
+      timeRemaining: 'Tiempo restante para el impacto:',
+      timeRemainingUnknown: 'Hora de impacto no disponible',
+      impactNow: 'Impacto en curso',
+      impactPaused: 'Impacto detectado — simulación en pausa.',
+      resume: 'Reanudar animación',
+      realTime: 'Ver en tiempo real',
+      exitRealTime: 'Salir de tiempo real',
+      realTimeActive: 'Modo en tiempo real'
     },
     impactMap: {
       title: 'Mapa de Impacto',


### PR DESCRIPTION
## Summary
- show the remaining time until impact above the 3D orbit view and pause the animation once Earth/impactor contact is detected, with a resume option
- add a real-time playback toggle alongside existing speed controls and pass the selected scenario impact date into the visualization
- localize the new orbit visualization strings for both English and Spanish interfaces

## Testing
- npm run build *(fails: existing merge-conflict markers and missing dependencies in unrelated files break the build)*

------
https://chatgpt.com/codex/tasks/task_e_68e1de60cd948331bddee03ae16f8c02