### PR TITLE
Resolve ImpactMap merge conflict and add missing type declarations

### DIFF
--- a/src/components/ImpactMap.tsx
+++ b/src/components/ImpactMap.tsx
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
-=======
-import { useEffect, useRef, useState } from 'react'
->>>>>>> Stashed changes
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import L from 'leaflet'
 import type { ImpactResults } from '../types'
 import type { GeologyAdjustedResults } from '../utils/geology'
@@ -34,7 +30,6 @@ interface ImpactMapProps {
   onLocationSelect: (lat: number, lng: number) => void
 }
 
-<<<<<<< Updated upstream
 const ImpactMap = forwardRef<ImpactMapHandle, ImpactMapProps>(
   ({ location, results, adjustedResults, onLocationSelect }, ref) => {
     const { t } = useLanguage()
@@ -44,18 +39,8 @@ const ImpactMap = forwardRef<ImpactMapHandle, ImpactMapProps>(
     const devRingRef = useRef<L.Circle | null>(null)
     const craterRingRef = useRef<L.Circle | null>(null)
     const tileLayerRef = useRef<L.TileLayer | null>(null)
-=======
-export default function ImpactMap({ location, results, adjustedResults, onLocationSelect }: ImpactMapProps) {
-  const { t } = useLanguage()
-  const mapRef = useRef<L.Map | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const impactMarkerRef = useRef<L.Marker | null>(null)
-  const devRingRef = useRef<L.Circle | null>(null)
-  const craterRingRef = useRef<L.Circle | null>(null)
-  const tileLayerRef = useRef<L.TileLayer | null>(null)
-  const [affectedCities, setAffectedCities] = useState<AffectedCity[]>([])
-  const [loadingCities, setLoadingCities] = useState(false)
->>>>>>> Stashed changes
+    const [affectedCities, setAffectedCities] = useState<AffectedCity[]>([])
+    const [loadingCities, setLoadingCities] = useState(false)
 
     // Initialize map
     useEffect(() => {
@@ -66,7 +51,7 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
 
       const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 15,
-        attribution: '&copy; OpenStreetMap contributors'
+        attribution: '&copy; OpenStreetMap contributors',
       })
       tileLayer.addTo(map)
       tileLayerRef.current = tileLayer
@@ -110,7 +95,7 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
         map.remove()
         mapRef.current = null
       }
-    }, [])
+    }, [location, onLocationSelect])
 
     // Update location
     useEffect(() => {
@@ -131,6 +116,32 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
     useEffect(() => {
       updateRings()
     }, [results, adjustedResults])
+
+    // Fetch affected cities when location or devastation radius changes
+    useEffect(() => {
+      const effectiveDevastation =
+        adjustedResults?.adjustedDevastationRadius ?? results?.devastationRadius
+
+      if (effectiveDevastation == null) {
+        setAffectedCities([])
+        return
+      }
+
+      const loadCities = async () => {
+        setLoadingCities(true)
+        try {
+          const cities = await fetchAffectedCities(location[0], location[1], effectiveDevastation)
+          setAffectedCities(cities)
+        } catch (error) {
+          console.error('Failed to load affected cities:', error)
+          setAffectedCities([])
+        } finally {
+          setLoadingCities(false)
+        }
+      }
+
+      loadCities()
+    }, [location, results, adjustedResults])
 
     const updateRings = () => {
       if (!mapRef.current || !impactMarkerRef.current) return
@@ -157,84 +168,11 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
       // Remove old rings
       if (devRingRef.current) {
         devRingRef.current.remove()
-<<<<<<< Updated upstream
-=======
         devRingRef.current = null
       }
-
       if (craterRingRef.current) {
         craterRingRef.current.remove()
         craterRingRef.current = null
-      }
-
-      // Remove map instance
-      map.remove()
-      mapRef.current = null
-    }
-  }, [])
-
-  // Update location
-  useEffect(() => {
-    if (!mapRef.current) return
-
-    // Update or create marker
-    if (impactMarkerRef.current) {
-      impactMarkerRef.current.remove()
-    }
-    const marker = L.marker(location, { title: 'Impact' }).addTo(mapRef.current)
-    impactMarkerRef.current = marker
-
-    // Update rings
-    updateRings()
-  }, [location])
-
-  // Update rings when results change
-  useEffect(() => {
-    updateRings()
-  }, [results, adjustedResults])
-
-  // Fetch affected cities when location or devastation radius changes
-  useEffect(() => {
-    const effectiveDevastation =
-      adjustedResults?.adjustedDevastationRadius ?? results?.devastationRadius
-
-    if (effectiveDevastation == null) {
-      setAffectedCities([])
-      return
-    }
-
-    const loadCities = async () => {
-      setLoadingCities(true)
-      try {
-        const cities = await fetchAffectedCities(location[0], location[1], effectiveDevastation)
-        setAffectedCities(cities)
-      } catch (error) {
-        console.error('Failed to load affected cities:', error)
-        setAffectedCities([])
-      } finally {
-        setLoadingCities(false)
-      }
-    }
-
-    loadCities()
-  }, [location, results, adjustedResults])
-
-  const updateRings = () => {
-    if (!mapRef.current || !impactMarkerRef.current) return
-
-    const effectiveDevastation =
-      adjustedResults?.adjustedDevastationRadius ?? results?.devastationRadius
-    const effectiveCrater =
-      adjustedResults?.adjustedCraterDiameter ?? results?.craterDiameter
-
-    if (effectiveDevastation == null || effectiveCrater == null) {
-      if (devRingRef.current) {
-        devRingRef.current.remove()
-        devRingRef.current = null
->>>>>>> Stashed changes
-      }
-      if (craterRingRef.current) {
-        craterRingRef.current.remove()
       }
 
       // Add new rings
@@ -245,7 +183,7 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
         radius: devRadius,
         color: '#f59e0b',
         fill: false,
-        weight: 2
+        weight: 2,
       }).addTo(mapRef.current)
       devRingRef.current = devRing
 
@@ -253,7 +191,7 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
         radius: craterRadius,
         color: '#ef4444',
         fill: false,
-        weight: 2
+        weight: 2,
       }).addTo(mapRef.current)
       craterRingRef.current = craterRing
     }
@@ -273,7 +211,7 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
           })
 
           return await new Promise<Blob | null>((resolve) => {
-            canvas.toBlob((blob) => resolve(blob), 'image/png')
+            canvas.toBlob((blob: Blob | null) => resolve(blob), 'image/png')
           })
         },
       }),
@@ -284,64 +222,57 @@ export default function ImpactMap({ location, results, adjustedResults, onLocati
       <div className="space-y-3">
         <h2 className="text-base sm:text-lg font-semibold pt-2">{t('impactMap.title')}</h2>
         <div ref={containerRef} className="w-full h-64 sm:h-80 rounded-xl border border-white/10" />
-        <div className="text-[10px] sm:text-xs label">
-          {t('impactMap.description')}
-        </div>
+        <div className="text-[10px] sm:text-xs label">{t('impactMap.description')}</div>
+
+        {/* Affected Cities List */}
+        {results && (
+          <div className="space-y-2">
+            <h3 className="text-sm sm:text-base font-semibold">{t('impactMap.affectedAreas')}</h3>
+
+            {loadingCities ? (
+              <div className="text-xs sm:text-sm label">{t('impactMap.loadingCities')}</div>
+            ) : affectedCities.length > 0 ? (
+              <div className="space-y-1">
+                <div className="text-[10px] sm:text-xs label">
+                  {t('impactMap.citiesInRange')}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-48 overflow-y-auto">
+                  {affectedCities.map((city, index) => (
+                    <div
+                      key={`${city.name}-${index}`}
+                      className="bg-white/5 rounded-lg p-2 border border-white/10"
+                    >
+                      <div className="flex justify-between items-start gap-2">
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs sm:text-sm font-medium truncate">
+                            {city.name}
+                          </div>
+                          <div className="text-[10px] sm:text-xs label capitalize">
+                            {city.type}
+                            {city.population && ` • ${formatPopulation(city.population)}`}
+                          </div>
+                        </div>
+                        <div className="text-[10px] sm:text-xs label whitespace-nowrap">
+                          {city.distance.toFixed(1)} km
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="text-xs sm:text-sm label">{t('impactMap.noCitiesFound')}</div>
+            )}
+          </div>
+        )}
       </div>
-<<<<<<< Updated upstream
     )
   }
-);
+)
 
 ImpactMap.displayName = 'ImpactMap'
 
 export default ImpactMap
-=======
-
-      {/* Affected Cities List */}
-      {results && (
-        <div className="space-y-2">
-          <h3 className="text-sm sm:text-base font-semibold">{t('impactMap.affectedAreas')}</h3>
-
-          {loadingCities ? (
-            <div className="text-xs sm:text-sm label">{t('impactMap.loadingCities')}</div>
-          ) : affectedCities.length > 0 ? (
-            <div className="space-y-1">
-              <div className="text-[10px] sm:text-xs label">
-                {t('impactMap.citiesInRange')}
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-48 overflow-y-auto">
-                {affectedCities.map((city, index) => (
-                  <div
-                    key={`${city.name}-${index}`}
-                    className="bg-white/5 rounded-lg p-2 border border-white/10"
-                  >
-                    <div className="flex justify-between items-start gap-2">
-                      <div className="flex-1 min-w-0">
-                        <div className="text-xs sm:text-sm font-medium truncate">
-                          {city.name}
-                        </div>
-                        <div className="text-[10px] sm:text-xs label capitalize">
-                          {city.type}
-                          {city.population && ` • ${formatPopulation(city.population)}`}
-                        </div>
-                      </div>
-                      <div className="text-[10px] sm:text-xs label whitespace-nowrap">
-                        {city.distance.toFixed(1)} km
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="text-xs sm:text-sm label">{t('impactMap.noCitiesFound')}</div>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
 
 function formatPopulation(pop: number): string {
   if (pop >= 1000000) {
@@ -351,4 +282,3 @@ function formatPopulation(pop: number): string {
   }
   return pop.toString()
 }
->>>>>>> Stashed changes

--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -1,0 +1,20 @@
+declare module 'html2canvas' {
+  type Html2CanvasOptions = {
+    backgroundColor?: string | null
+    useCORS?: boolean
+    scale?: number
+  }
+
+  const html2canvas: (element: HTMLElement, options?: Html2CanvasOptions) => Promise<HTMLCanvasElement>
+  export default html2canvas
+}
+
+declare module 'jspdf' {
+  export class jsPDF {
+    constructor(...args: unknown[])
+    setFontSize(size: number): void
+    text(text: string, x: number, y: number): void
+    addImage(...args: unknown[]): void
+    save(filename?: string): void
+  }
+}

--- a/src/utils/geocoding.ts
+++ b/src/utils/geocoding.ts
@@ -12,6 +12,20 @@ export interface AffectedCity {
  * @param radiusKm Radius in kilometers
  * @returns Array of affected cities
  */
+interface OverpassElement {
+  lat: number
+  lon: number
+  tags: {
+    name?: string
+    place?: string
+    population?: string
+  }
+}
+
+interface OverpassResponse {
+  elements?: OverpassElement[]
+}
+
 export async function fetchAffectedCities(
   lat: number,
   lng: number,
@@ -39,11 +53,12 @@ export async function fetchAffectedCities(
       throw new Error('Failed to fetch cities')
     }
 
-    const data = await response.json()
+    const data = (await response.json()) as OverpassResponse
+    const elements = data.elements ?? []
 
     // Process and sort by distance
-    const cities: AffectedCity[] = data.elements
-      .map((element: any) => {
+    const cities: AffectedCity[] = elements
+      .map((element) => {
         const cityLat = element.lat
         const cityLng = element.lon
         const distance = calculateDistance(lat, lng, cityLat, cityLng)


### PR DESCRIPTION
## Summary
- merge the ImpactMap implementations to restore the export handle alongside the affected cities panel and clean up lifecycle management
- add module declarations and stronger typing so TypeScript can resolve html2canvas/jspdf usage and geocoding responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e1df62908331a4ef6b918b6fca03