### PR TITLE
Reset Earth marker when loading new orbit

### DIFF
--- a/src/components/OrbitVisualization.tsx
+++ b/src/components/OrbitVisualization.tsx
@@ -322,6 +322,10 @@ const OrbitVisualization = forwardRef<OrbitVisualizationHandle, OrbitVisualizati
 
       currentOrbitRef.current = orbit
       asteroidMRef.current = 0 // reset position
+      earthMRef.current = 0
+      if (earthMarkerRef.current) {
+        earthMarkerRef.current.position.set(1, 0, 0)
+      }
       impactPauseRef.current = false
       setImpactPaused(false)
     }


### PR DESCRIPTION
## Summary
- reset the Earth's mean anomaly when a new orbit is loaded
- immediately reposition the Earth marker to its default location to keep simulations consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26efb5e708331b74a212887f7fe7d