### PR TITLE
Add labeled overlays to 3D orbit visualization

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -60,3 +60,18 @@ body {
   border: 1px solid var(--metric-border);
   transition: background-color 0.3s ease, border-color 0.3s ease;
 }
+
+.orbit-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: #ffffff;
+  background: rgba(11, 16, 32, 0.75);
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+  backdrop-filter: blur(4px);
+}


### PR DESCRIPTION
## Summary
- attach localized CSS2D labels to the Earth and asteroid markers in the orbit visualization
- render the label overlay alongside the WebGL canvas and update it on resize and language changes
- add styling for the orbit label pills and prepare the container for overlay positioning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27f8260788331ae1db4d7a7a022e2