### PR TITLE
Update impact countdown when collision detected

### DIFF
--- a/src/components/OrbitVisualization.tsx
+++ b/src/components/OrbitVisualization.tsx
@@ -276,7 +276,11 @@ const OrbitVisualization = forwardRef<OrbitVisualizationHandle, OrbitVisualizati
             ) {
               impactPauseRef.current = true
               proximityImpactRef.current = true
+              if (baseImpactDiffRef.current != null) {
+                simulatedElapsedRef.current = baseImpactDiffRef.current
+              }
               setImpactPaused(true)
+              setTimeRemainingLabel(translateRef.current('orbitViz.impactNow'))
             }
           }
 


### PR DESCRIPTION
## Summary
- ensure the orbit visualization countdown switches to "impact now" when the asteroid reaches the collision threshold
- sync the simulated elapsed time with the baseline so the countdown immediately reflects an impact pause

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a6e51dbc833183a2c953303fdde2