### PR TITLE
Preserve impact map zoom when updating location

### DIFF
--- a/src/components/ImpactMap.tsx
+++ b/src/components/ImpactMap.tsx
@@ -95,18 +95,23 @@ const ImpactMap = forwardRef<ImpactMapHandle, ImpactMapProps>(
         map.remove()
         mapRef.current = null
       }
-    }, [location, onLocationSelect])
+    }, [onLocationSelect])
 
     // Update location
     useEffect(() => {
       if (!mapRef.current) return
 
+      const map = mapRef.current
+      const currentZoom = map.getZoom()
+      map.setView(location, currentZoom)
+
       // Update or create marker
       if (impactMarkerRef.current) {
-        impactMarkerRef.current.remove()
+        impactMarkerRef.current.setLatLng(location)
+      } else {
+        const marker = L.marker(location, { title: 'Impact' }).addTo(map)
+        impactMarkerRef.current = marker
       }
-      const marker = L.marker(location, { title: 'Impact' }).addTo(mapRef.current)
-      impactMarkerRef.current = marker
 
       // Update rings
       updateRings()


### PR DESCRIPTION
## Summary
- prevent the Leaflet map from being re-created when the impact location changes
- keep the current zoom level while updating the marker position to the newly selected point

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b819b67c8331a380f298461efb46